### PR TITLE
Indent with spaces instead of tabs

### DIFF
--- a/docker-softhsm/crypki.conf.sample
+++ b/docker-softhsm/crypki.conf.sample
@@ -18,12 +18,12 @@
                 "ssh-host-key"
             ]
         },
-	{
-	    "Endpoint": "/sig/blob",
-	    "Identifiers": [
-	        "sign-blob-key"
-	    ]
-	}
+        {
+            "Endpoint": "/sig/blob",
+            "Identifiers": [
+                "sign-blob-key"
+            ]
+        }
     ],
     "Keys": [
         {


### PR DESCRIPTION
The tabs seemed to be mixed up in the sample configuration file, so I have changed them to spaces.

***
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
