### PR TITLE
add tlshost option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	defaultTLSServerCertPath = "/opt/crypki/server.crt"
 	defaultTLSCACertPath     = "/opt/crypki/ca.crt"
 	defaultTLSServerKeyPath  = "/opt/crypki/server.key"
+	defaultTLSHost           = ""
 	defaultTLSPort           = "4443"
 	defaultPoolSize          = 2
 	defaultKeyType           = crypki.RSA
@@ -87,6 +88,7 @@ type Config struct {
 	TLSServerCertPath string
 	TLSServerKeyPath  string
 	TLSCACertPath     string
+	TLSHost           string
 	TLSPort           string
 	SignersPerPool    int
 	Keys              []KeyConfig
@@ -178,6 +180,9 @@ func (c *Config) loadDefaults() {
 	}
 	if c.SignersPerPool == 0 {
 		c.SignersPerPool = defaultPoolSize
+	}
+	if strings.TrimSpace(c.TLSHost) == "" {
+		c.TLSHost = defaultTLSHost
 	}
 	if strings.TrimSpace(c.TLSPort) == "" {
 		c.TLSPort = defaultTLSPort

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@ func TestParse(t *testing.T) {
 		TLSClientAuthMode: 4,
 		TLSServerCertPath: "/opt/crypki/server.crt",
 		TLSServerKeyPath:  "/opt/crypki/server.key",
+		TLSHost:           "",
 		TLSPort:           "4443",
 		SignersPerPool:    2,
 		Keys: []KeyConfig{

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func Main(keyP crypki.KeyIDProcessor) {
 
 	proto.RegisterSigningServer(grpcServer, ss)
 
-	server := initHTTPServer(ctx, tlsConfig, grpcServer, gwmux, net.JoinHostPort("", cfg.TLSPort))
+	server := initHTTPServer(ctx, tlsConfig, grpcServer, gwmux, net.JoinHostPort(cfg.TLSHost, cfg.TLSPort))
 
 	listener, err := net.Listen("tcp", server.Addr)
 	if err != nil {


### PR DESCRIPTION
I want to restrict listen addr like 'localhost'. It is helpful in cases like working with proxy e.g. nginx.
(Access control is assumed to be done by proxy instead of crypki's mtls.)

The default setting is the same as before.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
