### PR TITLE
GitHub Actions versions we use to the same one

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.14.4', '1.13.12' ]
+        go: [ '1.14.x', '1.13.x' ]
     name: Go ${{ matrix.go }} build
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v2
+
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
     - name: install go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
-
-    - name: checkout
-      uses: actions/checkout@v1
 
     - name: get version
       id: v


### PR DESCRIPTION
I have matched GitHub Actions versions we use to the same one in linux and release workflows.

***

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
