### PR TITLE
Log the correct status code when panic

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -27,9 +27,11 @@ func (s *SigningService) GetBlobAvailableSigningKeys(ctx context.Context, e *emp
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.BlobEndpoint] {
@@ -47,9 +49,11 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -80,9 +84,12 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,digest=%q,hash=%q,st=%d,et=%d,err="%v"`, methodName, request.GetDigest(), request.HashAlgorithm.String(), statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,digest=%q,hash=%q,st=%d,et=%d,err="%v"`,
+				methodName, request.GetDigest(), request.HashAlgorithm.String(), statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/blob.go
+++ b/api/blob.go
@@ -26,12 +26,10 @@ func (s *SigningService) GetBlobAvailableSigningKeys(ctx context.Context, e *emp
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.BlobEndpoint] {
@@ -48,12 +46,10 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -83,13 +79,11 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,digest=%q,hash=%q,st=%d,et=%d,err="%v"`,
-				methodName, request.GetDigest(), request.HashAlgorithm.String(), statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,digest=%q,hash=%q,st=%d,et=%d,err="%v"`,
+			methodName, request.GetDigest(), request.HashAlgorithm.String(), statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/log.go
+++ b/api/log.go
@@ -7,8 +7,6 @@ import (
 
 type logFunc func(statusCode int, err error)
 
-const panicRecoveryPrefix = "panic: "
-
 // logWithCheckingPanic attemps to recover from a possible panic,
 // modifies statusCode and err if there was indeed a panic,
 // passes the possibly updated status and err to the logFunc,
@@ -17,7 +15,7 @@ const panicRecoveryPrefix = "panic: "
 func logWithCheckingPanic(f logFunc, statusCode int, err error) {
 	if r := recover(); r != nil {
 		statusCode = http.StatusInternalServerError
-		err = fmt.Errorf("%s%v", panicRecoveryPrefix, r)
+		err = fmt.Errorf("panic: %v", r)
 		defer panic(r)
 	}
 	f(statusCode, err)

--- a/api/log.go
+++ b/api/log.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type logFunc func(statusCode int, err error)
+
+// logWithCheckingPanic attemps to recover from a possible panic,
+// modifies statusCode and err if there was indeed a panic,
+// passes the possibly updated status and err to the logFunc,
+// then panics again if there was indeed a panic to
+// make UnaryInterceptor in server/server.go return "internal server error" to the client.
+func logWithCheckingPanic(f logFunc, statusCode int, err error) {
+	if r := recover(); r != nil {
+		statusCode = http.StatusInternalServerError
+		err = fmt.Errorf("panic: %v", r)
+		defer panic(r)
+	}
+	f(statusCode, err)
+}

--- a/api/log.go
+++ b/api/log.go
@@ -7,6 +7,8 @@ import (
 
 type logFunc func(statusCode int, err error)
 
+const panicRecoveryPrefix = "panic: "
+
 // logWithCheckingPanic attemps to recover from a possible panic,
 // modifies statusCode and err if there was indeed a panic,
 // passes the possibly updated status and err to the logFunc,
@@ -15,7 +17,7 @@ type logFunc func(statusCode int, err error)
 func logWithCheckingPanic(f logFunc, statusCode int, err error) {
 	if r := recover(); r != nil {
 		statusCode = http.StatusInternalServerError
-		err = fmt.Errorf("panic: %v", r)
+		err = fmt.Errorf("%s%v", panicRecoveryPrefix, r)
 		defer panic(r)
 	}
 	f(statusCode, err)

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -46,16 +46,14 @@ func testLogWithCheckingPanic(t *testing.T, tc *logTestCase) {
 		want = fmt.Sprintf(logStr, inputStatusCode, inputError)
 	}
 
-	// Make the channel buffered to avoid deadlock.
-	logC := make(chan string, 1)
+	got := ""
 	f := func(statusCode int, err error) {
-		logC <- fmt.Sprintf(logStr, statusCode, err)
+		got = fmt.Sprintf(logStr, statusCode, err)
 	}
 
 	defer func() {
 		// Capture the panic thrown from logWithCheckingPanic.
 		recover()
-		got := <-logC
 		if got != want {
 			t.Errorf("%s failed, got: %s, want: %s", tc.name, got, want)
 		}

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -40,7 +40,7 @@ func TestLogWithCheckingPanic(t *testing.T) {
 			)
 			var inputError error
 
-			want := fmt.Sprintf(logStr, http.StatusInternalServerError, "panic: "+fmt.Sprintf("%s", tc.panicInput))
+			want := fmt.Sprintf(logStr, http.StatusInternalServerError, panicRecoveryPrefix+fmt.Sprintf("%s", tc.panicInput))
 			if tc.panicInput == nil {
 				want = fmt.Sprintf(logStr, inputStatusCode, inputError)
 			}

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type logTestCase struct {
-	name string
+	name       string
 	panicInput interface{}
 }
 
@@ -16,19 +16,19 @@ func TestLogWithCheckingPanic(t *testing.T) {
 	t.Parallel()
 	testCases := []*logTestCase{
 		{
-			name: "panic with string",
+			name:       "panic with string",
 			panicInput: "string",
 		},
 		{
-			name: "panic with error",
+			name:       "panic with error",
 			panicInput: errors.New("error"),
 		},
 		{
-			name: "no panic",
+			name:       "no panic",
 			panicInput: nil,
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		testLogWithCheckingPanic(t, tc)
 	}
@@ -36,12 +36,12 @@ func TestLogWithCheckingPanic(t *testing.T) {
 
 func testLogWithCheckingPanic(t *testing.T, tc *logTestCase) {
 	const (
-		logStr = "st: %d, err: %v"
+		logStr          = "st: %d, err: %v"
 		inputStatusCode = http.StatusOK
 	)
 	var inputError error
 
-	want := fmt.Sprintf(logStr, http.StatusInternalServerError, "panic: " + fmt.Sprintf("%s", tc.panicInput))
+	want := fmt.Sprintf(logStr, http.StatusInternalServerError, "panic: "+fmt.Sprintf("%s", tc.panicInput))
 	if tc.panicInput == nil {
 		want = fmt.Sprintf(logStr, inputStatusCode, inputError)
 	}
@@ -56,7 +56,7 @@ func testLogWithCheckingPanic(t *testing.T, tc *logTestCase) {
 		// Capture the panic thrown from logWithCheckingPanic.
 		recover()
 		got := <-logC
-		if get != want {
+		if got != want {
 			t.Errorf("%s failed, got: %s, want: %s", tc.name, got, want)
 		}
 	}()

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+type logTestCase struct {
+	name string
+	panicInput interface{}
+}
+
+func TestLogWithCheckingPanic(t *testing.T) {
+	t.Parallel()
+	testCases := []*logTestCase{
+		{
+			name: "panic with string",
+			panicInput: "string",
+		},
+		{
+			name: "panic with error",
+			panicInput: errors.New("error"),
+		},
+		{
+			name: "no panic",
+			panicInput: nil,
+		},
+	}
+	
+	for _, tc := range testCases {
+		testLogWithCheckingPanic(t, tc)
+	}
+}
+
+func testLogWithCheckingPanic(t *testing.T, tc *logTestCase) {
+	const (
+		logStr = "st: %d, err: %v"
+		inputStatusCode = http.StatusOK
+	)
+	var inputError error
+
+	want := fmt.Sprintf(logStr, http.StatusInternalServerError, "panic: " + fmt.Sprintf("%s", tc.panicInput))
+	if tc.panicInput == nil {
+		want = fmt.Sprintf(logStr, inputStatusCode, inputError)
+	}
+
+	// Make the channel buffered to avoid deadlock.
+	logC := make(chan string, 1)
+	f := func(statusCode int, err error) {
+		logC <- fmt.Sprintf(logStr, statusCode, err)
+	}
+
+	defer func() {
+		// Capture the panic thrown from logWithCheckingPanic.
+		recover()
+		got := <-logC
+		if get != want {
+			t.Errorf("%s failed, got: %s, want: %s", tc.name, got, want)
+		}
+	}()
+	defer logWithCheckingPanic(f, inputStatusCode, inputError)
+	panic(tc.panicInput)
+}

--- a/api/sign.go
+++ b/api/sign.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/theparanoids/crypki"
@@ -17,14 +16,6 @@ type SigningService struct {
 	crypki.KeyIDProcessor
 	KeyUsages   map[string]map[string]bool
 	MaxValidity map[string]uint64
-}
-
-// recoverIfPanicked recovers from panic and logs the error.
-func recoverIfPanicked(method string) {
-	if r := recover(); r != nil {
-		log.Printf("%s: recovered from panic, panic: %v", method, r)
-		panic(r)
-	}
 }
 
 // timeElapsedSince returns time elapsed since start time in microseconds.

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -27,9 +27,11 @@ func (s *SigningService) GetHostSSHCertificateAvailableSigningKeys(ctx context.C
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHHostCertEndpoint] {
@@ -47,9 +49,11 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -84,9 +88,12 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		if cert != nil {
 			kid = cert.KeyId
 		}
-		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`, methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
+				methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -26,12 +26,10 @@ func (s *SigningService) GetHostSSHCertificateAvailableSigningKeys(ctx context.C
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHHostCertEndpoint] {
@@ -48,12 +46,10 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -83,17 +79,15 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 	var err error
 	var cert *ssh.Certificate
 
-	defer func() {
+	f := func(statusCode int, err error) {
 		kid := ""
 		if cert != nil {
 			kid = cert.KeyId
 		}
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
-				methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
+			methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -26,12 +26,10 @@ func (s *SigningService) GetUserSSHCertificateAvailableSigningKeys(ctx context.C
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHUserCertEndpoint] {
@@ -48,12 +46,10 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -83,17 +79,15 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 	var err error
 	var cert *ssh.Certificate
 
-	defer func() {
+	f := func(statusCode int, err error) {
 		kid := ""
 		if cert != nil {
 			kid = cert.KeyId
 		}
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
-				methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
+			methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -27,9 +27,11 @@ func (s *SigningService) GetUserSSHCertificateAvailableSigningKeys(ctx context.C
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHUserCertEndpoint] {
@@ -47,9 +49,11 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -84,9 +88,12 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		if cert != nil {
 			kid = cert.KeyId
 		}
-		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`, methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
+				methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -26,12 +26,10 @@ func (s *SigningService) GetX509CertificateAvailableSigningKeys(ctx context.Cont
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.X509CertEndpoint] {
@@ -47,12 +45,10 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 	start := time.Now()
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -82,12 +78,10 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	subject := pkix.Name{}
 	var err error
 
-	defer func() {
-		f := func(statusCode int, err error) {
-			log.Printf(`m=%s,sub=%q,st=%d,et=%d,err="%v"`, methodName, subject, statusCode, timeElapsedSince(start), err)
-		}
-		logWithCheckingPanic(f, statusCode, err)
-	}()
+	f := func(statusCode int, err error) {
+		log.Printf(`m=%s,sub=%q,st=%d,et=%d,err="%v"`, methodName, subject, statusCode, timeElapsedSince(start), err)
+	}
+	defer logWithCheckingPanic(f, statusCode, err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -27,9 +27,11 @@ func (s *SigningService) GetX509CertificateAvailableSigningKeys(ctx context.Cont
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.X509CertEndpoint] {
@@ -46,9 +48,11 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -79,9 +83,11 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	var err error
 
 	defer func() {
-		log.Printf(`m=%s,sub=%q,st=%d,et=%d,err="%v"`, methodName, subject, statusCode, timeElapsedSince(start), err)
+		f := func(statusCode int, err error) {
+			log.Printf(`m=%s,sub=%q,st=%d,et=%d,err="%v"`, methodName, subject, statusCode, timeElapsedSince(start), err)
+		}
+		logWithCheckingPanic(f, statusCode, err)
 	}()
-	defer recoverIfPanicked(methodName)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest


### PR DESCRIPTION
After #35, if the server panics, we return `codes.Internal` to client in `grpc.UnaryInterceptor`. However, we still log the "default status code" (e.g. 201 for [PostX509Certificate](https://github.com/theparanoids/crypki/blob/ac66b39615ccb28407203c7566c53f2351e42b9c/api/x509cert.go#L76)) instead of 500, and this PR aims to solve the inconsistency.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
