### PR TITLE
Fix log when error is occurred without panic

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -29,7 +29,7 @@ func (s *SigningService) GetBlobAvailableSigningKeys(ctx context.Context, e *emp
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.BlobEndpoint] {
@@ -49,7 +49,7 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -83,7 +83,7 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 		log.Printf(`m=%s,digest=%q,hash=%q,st=%d,et=%d,err="%v"`,
 			methodName, request.GetDigest(), request.HashAlgorithm.String(), statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/log.go
+++ b/api/log.go
@@ -12,11 +12,11 @@ type logFunc func(statusCode int, err error)
 // passes the possibly updated status and err to the logFunc,
 // then panics again if there was indeed a panic to
 // make UnaryInterceptor in server/server.go return "internal server error" to the client.
-func logWithCheckingPanic(f logFunc, statusCode int, err error) {
+func logWithCheckingPanic(f logFunc, statusCode *int, err *error) {
 	if r := recover(); r != nil {
-		statusCode = http.StatusInternalServerError
-		err = fmt.Errorf("panic: %v", r)
+		*statusCode = http.StatusInternalServerError
+		*err = fmt.Errorf("panic: %v", r)
 		defer panic(r)
 	}
-	f(statusCode, err)
+	f(*statusCode, *err)
 }

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -35,7 +35,7 @@ func TestLogWithCheckingPanic(t *testing.T) {
 			statusCode: http.StatusOK,
 			err:        nil,
 			panic:      nil,
-			want:       "st: 200, err: <nil>", // See inputStatusCode below for 200
+			want:       "st: 200, err: <nil>",
 		},
 		{
 			name:       "no panic with error",

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -10,31 +10,42 @@ import (
 func TestLogWithCheckingPanic(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name  string
-		input interface{}
-		want  string // See logStr below for the format
+		name       string
+		statusCode int
+		err        error
+		panic      interface{}
+		want       string // See logStr below for the format
 	}{
 		{
-			name:  "panic with string",
-			input: "string",
-			want:  "st: 500, err: panic: string",
+			name:       "panic with string",
+			statusCode: http.StatusOK,
+			err:        nil,
+			panic:      "string",
+			want:       "st: 500, err: panic: string",
 		},
 		{
-			name:  "panic with error",
-			input: errors.New("error"),
-			want:  "st: 500, err: panic: error",
+			name:       "panic with error",
+			statusCode: http.StatusOK,
+			err:        nil,
+			panic:      errors.New("error"),
+			want:       "st: 500, err: panic: error",
 		},
 		{
-			name:  "no panic",
-			input: nil,
-			want:  "st: 200, err: <nil>", // See inputStatusCode below for 200
+			name:       "no panic",
+			statusCode: http.StatusOK,
+			err:        nil,
+			panic:      nil,
+			want:       "st: 200, err: <nil>", // See inputStatusCode below for 200
+		},
+		{
+			name:       "no panic with error",
+			statusCode: http.StatusBadRequest,
+			err:        errors.New("bad request"),
+			panic:      nil,
+			want:       "st: 400, err: bad request",
 		},
 	}
-	const (
-		logStr          = "st: %d, err: %v"
-		inputStatusCode = http.StatusOK
-	)
-	var inputError error
+	const logStr = "st: %d, err: %v"
 
 	for _, tc := range testCases {
 		// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
@@ -54,8 +65,12 @@ func TestLogWithCheckingPanic(t *testing.T) {
 					t.Errorf("got: %q, want: %q", got, tc.want)
 				}
 			}()
-			defer logWithCheckingPanic(f, inputStatusCode, inputError)
-			panic(tc.input)
+			statusCode := http.StatusOK
+			var err error
+			defer logWithCheckingPanic(f, &statusCode, &err)
+			statusCode = tc.statusCode
+			err = tc.err
+			panic(tc.panic)
 		})
 	}
 }

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -65,7 +65,7 @@ func TestLogWithCheckingPanic(t *testing.T) {
 					t.Errorf("got: %q, want: %q", got, tc.want)
 				}
 			}()
-			statusCode := http.StatusOK
+			var statusCode int
 			var err error
 			defer logWithCheckingPanic(f, &statusCode, &err)
 			statusCode = tc.statusCode

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -29,7 +29,7 @@ func (s *SigningService) GetHostSSHCertificateAvailableSigningKeys(ctx context.C
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHHostCertEndpoint] {
@@ -49,7 +49,7 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -87,7 +87,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
 			methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -29,7 +29,7 @@ func (s *SigningService) GetUserSSHCertificateAvailableSigningKeys(ctx context.C
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.SSHUserCertEndpoint] {
@@ -49,7 +49,7 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -87,7 +87,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		log.Printf(`m=%s,id=%q,principals=%q,st=%d,et=%d,err="%v"`,
 			methodName, kid, request.Principals, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -29,7 +29,7 @@ func (s *SigningService) GetX509CertificateAvailableSigningKeys(ctx context.Cont
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	var keys []*proto.KeyMeta
 	for id := range s.KeyUsages[config.X509CertEndpoint] {
@@ -48,7 +48,7 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,st=%d,et=%d,err="%v"`, methodName, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if keyMeta == nil {
 		statusCode = http.StatusBadRequest
@@ -81,7 +81,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	f := func(statusCode int, err error) {
 		log.Printf(`m=%s,sub=%q,st=%d,et=%d,err="%v"`, methodName, subject, statusCode, timeElapsedSince(start), err)
 	}
-	defer logWithCheckingPanic(f, statusCode, err)
+	defer logWithCheckingPanic(f, &statusCode, &err)
 
 	if request.KeyMeta == nil {
 		statusCode = http.StatusBadRequest


### PR DESCRIPTION
`logWithCheckingPanic()` output incorrect statusCode and error now.
Because the function arguments are evaluated as usual. (ref. https://golang.org/ref/spec#Defer_statements
( playground sample: https://play.golang.org/p/IJ2amM417mC )

This PR change the function argument to pass-by-reference to fix it.
Additionally i added a test in case of the error without panic.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
