### PR TITLE
Shutdown on frequent internal service error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,10 +98,12 @@ type Config struct {
 	Keys              []KeyConfig
 	KeyUsages         []KeyUsage
 
-	ShutdownOnFrequentSigningFailure            bool
-	ShutdownOnSigningFailureConsecutiveCount    uint
-	ShutdownOnSigningFailureTimerDurationSecond uint
-	ShutdownOnSigningFailureTimerCount          uint
+	ShutdownOnFrequentSigningFailure bool
+	ShutdownOnSigningFailureCriteria struct {
+		ConsecutiveCountLimit uint
+		TimerDurationSecond   uint
+		TimerCountLimit       uint
+	}
 }
 
 // Parse loads configuration values from input file and returns config object and CA cert.
@@ -205,13 +207,13 @@ func (c *Config) loadDefaults() {
 		}
 	}
 
-	if c.ShutdownOnSigningFailureConsecutiveCount == 0 {
-		c.ShutdownOnSigningFailureConsecutiveCount = defaultShutdownOnSigningFailureConsecutiveCount
+	if c.ShutdownOnSigningFailureCriteria.ConsecutiveCountLimit == 0 {
+		c.ShutdownOnSigningFailureCriteria.ConsecutiveCountLimit = defaultShutdownOnSigningFailureConsecutiveCount
 	}
-	if c.ShutdownOnSigningFailureTimerDurationSecond == 0 {
-		c.ShutdownOnSigningFailureTimerDurationSecond = defaultShutdownOnSigningFailureTimerDurationSecond
+	if c.ShutdownOnSigningFailureCriteria.TimerDurationSecond == 0 {
+		c.ShutdownOnSigningFailureCriteria.TimerDurationSecond = defaultShutdownOnSigningFailureTimerDurationSecond
 	}
-	if c.ShutdownOnSigningFailureTimerCount == 0 {
-		c.ShutdownOnSigningFailureTimerCount = defaultShutdownOnSigningFailureTimerCount
+	if c.ShutdownOnSigningFailureCriteria.TimerCountLimit == 0 {
+		c.ShutdownOnSigningFailureCriteria.TimerCountLimit = defaultShutdownOnSigningFailureTimerCount
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -93,6 +93,8 @@ type Config struct {
 	SignersPerPool    int
 	Keys              []KeyConfig
 	KeyUsages         []KeyUsage
+
+	ShutdownOnFrequentSigningFailure bool
 }
 
 // Parse loads configuration values from input file and returns config object and CA cert.

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,10 @@ const (
 	defaultPoolSize          = 2
 	defaultKeyType           = crypki.RSA
 
+	defaultShutdownOnSigningFailureConsecutiveCount    = 4
+	defaultShutdownOnSigningFailureTimerDurationSecond = 60
+	defaultShutdownOnSigningFailureTimerCount          = 10
+
 	// X509CertEndpoint specifies the endpoint for signing X509 certificate.
 	X509CertEndpoint = "/sig/x509-cert"
 	// SSHUserCertEndpoint specifies the endpoint for signing SSH user certificate.
@@ -94,7 +98,10 @@ type Config struct {
 	Keys              []KeyConfig
 	KeyUsages         []KeyUsage
 
-	ShutdownOnFrequentSigningFailure bool
+	ShutdownOnFrequentSigningFailure            bool
+	ShutdownOnSigningFailureConsecutiveCount    uint
+	ShutdownOnSigningFailureTimerDurationSecond uint
+	ShutdownOnSigningFailureTimerCount          uint
 }
 
 // Parse loads configuration values from input file and returns config object and CA cert.
@@ -196,5 +203,15 @@ func (c *Config) loadDefaults() {
 		if c.Keys[i].SessionPoolSize == 0 {
 			c.Keys[i].SessionPoolSize = defaultPoolSize
 		}
+	}
+
+	if c.ShutdownOnSigningFailureConsecutiveCount == 0 {
+		c.ShutdownOnSigningFailureConsecutiveCount = defaultShutdownOnSigningFailureConsecutiveCount
+	}
+	if c.ShutdownOnSigningFailureTimerDurationSecond == 0 {
+		c.ShutdownOnSigningFailureTimerDurationSecond = defaultShutdownOnSigningFailureTimerDurationSecond
+	}
+	if c.ShutdownOnSigningFailureTimerCount == 0 {
+		c.ShutdownOnSigningFailureTimerCount = defaultShutdownOnSigningFailureTimerCount
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,10 +30,16 @@ func TestParse(t *testing.T) {
 			{"/sig/ssh-user-cert", []string{"key3"}, 36000},
 			{"/sig/blob", []string{"key1"}, 36000},
 		},
-		ShutdownOnFrequentSigningFailure:            true,
-		ShutdownOnSigningFailureConsecutiveCount:    3,
-		ShutdownOnSigningFailureTimerDurationSecond: 120,
-		ShutdownOnSigningFailureTimerCount:          20,
+		ShutdownOnFrequentSigningFailure: true,
+		ShutdownOnSigningFailureCriteria: struct {
+			ConsecutiveCountLimit uint
+			TimerDurationSecond   uint
+			TimerCountLimit       uint
+		}{
+			ConsecutiveCountLimit: 3,
+			TimerDurationSecond:   120,
+			TimerCountLimit:       20,
+		},
 	}
 	testcases := map[string]struct {
 		filePath    string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,10 @@ func TestParse(t *testing.T) {
 			{"/sig/ssh-user-cert", []string{"key3"}, 36000},
 			{"/sig/blob", []string{"key1"}, 36000},
 		},
-		ShutdownOnFrequentSigningFailure: true,
+		ShutdownOnFrequentSigningFailure:            true,
+		ShutdownOnSigningFailureConsecutiveCount:    3,
+		ShutdownOnSigningFailureTimerDurationSecond: 120,
+		ShutdownOnSigningFailureTimerCount:          20,
 	}
 	testcases := map[string]struct {
 		filePath    string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ func TestParse(t *testing.T) {
 			{"/sig/ssh-user-cert", []string{"key3"}, 36000},
 			{"/sig/blob", []string{"key1"}, 36000},
 		},
+		ShutdownOnFrequentSigningFailure: true,
 	}
 	testcases := map[string]struct {
 		filePath    string

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -14,7 +14,9 @@
     {"Endpoint": "/sig/ssh-user-cert", "Identifiers": ["key3"], "MaxValidity": 36000},
     {"Endpoint": "/sig/blob", "Identifiers": ["key1"], "MaxValidity": 36000}
   ],
-	"ShutdownOnSigningFailureConsecutiveCount":  3,
-	"ShutdownOnSigningFailureTimerDurationSecond": 120,
-	"ShutdownOnSigningFailureTimerCount":  20
+  "ShutdownOnSigningFailureCriteria": {
+    "ConsecutiveCountLimit": 3,
+    "TimerDurationSecond": 120,
+    "TimerCountLimit": 20
+  }
 }

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -1,4 +1,5 @@
 {
+  "ShutdownOnFrequentSigningFailure": true,
   "TLSServerName": "foo.example.com",
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -13,5 +13,8 @@
     {"Endpoint": "/sig/ssh-host-cert", "Identifiers": ["key1", "key2"], "MaxValidity": 36000},
     {"Endpoint": "/sig/ssh-user-cert", "Identifiers": ["key3"], "MaxValidity": 36000},
     {"Endpoint": "/sig/blob", "Identifiers": ["key1"], "MaxValidity": 36000}
-  ]
+  ],
+	"ShutdownOnSigningFailureConsecutiveCount":  3,
+	"ShutdownOnSigningFailureTimerDurationSecond": 120,
+	"ShutdownOnSigningFailureTimerCount":  20
 }

--- a/server/interceptor.go
+++ b/server/interceptor.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// StatusInterceptor returns a UnaryServerInterceptor that provides a hook to access the
+// grpc status code for each request.
+func StatusInterceptor(fn func(code codes.Code)) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		resp, err := handler(ctx, req)
+
+		// determine status code
+		var code codes.Code
+		if err != nil {
+			if sts, ok := status.FromError(err); !ok {
+				code = codes.Unknown
+			} else {
+				code = sts.Code()
+			}
+		} else {
+			code = codes.OK
+		}
+
+		fn(code)
+		return resp, err
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -178,8 +178,8 @@ func Main(keyP crypki.KeyIDProcessor) {
 		criteria := cfg.ShutdownOnSigningFailureCriteria
 		shutdownCounterConfig := shutdownCounterConfig{
 			consecutiveCountLimit: int32(criteria.ConsecutiveCountLimit),
-			timeRangeCountLimit:   int32(criteria.TimerDurationSecond),
-			tickerDuration:        time.Duration(criteria.TimerCountLimit) * time.Second,
+			timeRangeCountLimit:   int32(criteria.TimerCountLimit),
+			tickerDuration:        time.Duration(criteria.TimerDurationSecond) * time.Second,
 			shutdownFn: func() {
 				if err := server.Shutdown(ctx); err != nil {
 					log.Fatalf("failed to shutdown server: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -175,7 +175,7 @@ func Main(keyP crypki.KeyIDProcessor) {
 		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
 	}
 	if cfg.ShutdownOnFrequentSigningFailure {
-		config := shutdownCounterConfig{
+		shutdownCounterConfig := shutdownCounterConfig{
 			consecutiveCountLimit: int32(cfg.ShutdownOnSigningFailureConsecutiveCount),
 			timeRangeCountLimit:   int32(cfg.ShutdownOnSigningFailureTimerCount),
 			tickerDuration:        time.Duration(cfg.ShutdownOnSigningFailureTimerDurationSecond) * time.Second,
@@ -185,7 +185,9 @@ func Main(keyP crypki.KeyIDProcessor) {
 				}
 			},
 		}
-		interceptors = append(interceptors, StatusInterceptor((newShutdownCounter(config)).Interceptor))
+		interceptors = append([]grpc.UnaryServerInterceptor{
+			StatusInterceptor((newShutdownCounter(shutdownCounterConfig)).Interceptor),
+		}, interceptors...)
 	}
 
 	// Setup gRPC server and http server

--- a/server/server.go
+++ b/server/server.go
@@ -175,10 +175,11 @@ func Main(keyP crypki.KeyIDProcessor) {
 		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
 	}
 	if cfg.ShutdownOnFrequentSigningFailure {
+		criteria := cfg.ShutdownOnSigningFailureCriteria
 		shutdownCounterConfig := shutdownCounterConfig{
-			consecutiveCountLimit: int32(cfg.ShutdownOnSigningFailureConsecutiveCount),
-			timeRangeCountLimit:   int32(cfg.ShutdownOnSigningFailureTimerCount),
-			tickerDuration:        time.Duration(cfg.ShutdownOnSigningFailureTimerDurationSecond) * time.Second,
+			consecutiveCountLimit: int32(criteria.ConsecutiveCountLimit),
+			timeRangeCountLimit:   int32(criteria.TimerDurationSecond),
+			tickerDuration:        time.Duration(criteria.TimerCountLimit) * time.Second,
 			shutdownFn: func() {
 				if err := server.Shutdown(ctx); err != nil {
 					log.Fatalf("failed to shutdown server: %v", err)


### PR DESCRIPTION
This PR adds a new feature (default to be disabled and can be enabled through config) to shutdown the server when the underlying signing service fails to handle signing requests too frequently. Once the feature is enabled, the server could be shutdown when one of  the following conditions meets:
* when the server fails to handle signing requests 4 times in a row, or
* when the server fails to handle signing requests 10 times within 1 minutes.

We assume the signing service returns internal service error when the operation fails. Therefore, a grpc interceptor is injected to monitor the returned status code.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
