### PR TITLE
Improved naming and logging for shutdown-on-internal-failure feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,8 +98,9 @@ type Config struct {
 	Keys              []KeyConfig
 	KeyUsages         []KeyUsage
 
-	ShutdownOnFrequentSigningFailure bool
-	ShutdownOnSigningFailureCriteria struct {
+	ShutdownOnInternalFailure         bool
+	ShutdownOnInternalFailureCriteria struct {
+		ReportMode            bool
 		ConsecutiveCountLimit uint
 		TimerDurationSecond   uint
 		TimerCountLimit       uint
@@ -207,13 +208,13 @@ func (c *Config) loadDefaults() {
 		}
 	}
 
-	if c.ShutdownOnSigningFailureCriteria.ConsecutiveCountLimit == 0 {
-		c.ShutdownOnSigningFailureCriteria.ConsecutiveCountLimit = defaultShutdownOnSigningFailureConsecutiveCount
+	if c.ShutdownOnInternalFailureCriteria.ConsecutiveCountLimit == 0 {
+		c.ShutdownOnInternalFailureCriteria.ConsecutiveCountLimit = defaultShutdownOnSigningFailureConsecutiveCount
 	}
-	if c.ShutdownOnSigningFailureCriteria.TimerDurationSecond == 0 {
-		c.ShutdownOnSigningFailureCriteria.TimerDurationSecond = defaultShutdownOnSigningFailureTimerDurationSecond
+	if c.ShutdownOnInternalFailureCriteria.TimerDurationSecond == 0 {
+		c.ShutdownOnInternalFailureCriteria.TimerDurationSecond = defaultShutdownOnSigningFailureTimerDurationSecond
 	}
-	if c.ShutdownOnSigningFailureCriteria.TimerCountLimit == 0 {
-		c.ShutdownOnSigningFailureCriteria.TimerCountLimit = defaultShutdownOnSigningFailureTimerCount
+	if c.ShutdownOnInternalFailureCriteria.TimerCountLimit == 0 {
+		c.ShutdownOnInternalFailureCriteria.TimerCountLimit = defaultShutdownOnSigningFailureTimerCount
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,12 +30,14 @@ func TestParse(t *testing.T) {
 			{"/sig/ssh-user-cert", []string{"key3"}, 36000},
 			{"/sig/blob", []string{"key1"}, 36000},
 		},
-		ShutdownOnFrequentSigningFailure: true,
-		ShutdownOnSigningFailureCriteria: struct {
+		ShutdownOnInternalFailure: true,
+		ShutdownOnInternalFailureCriteria: struct {
+			ReportMode            bool
 			ConsecutiveCountLimit uint
 			TimerDurationSecond   uint
 			TimerCountLimit       uint
 		}{
+			ReportMode:            true,
 			ConsecutiveCountLimit: 3,
 			TimerDurationSecond:   120,
 			TimerCountLimit:       20,

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -1,5 +1,5 @@
 {
-  "ShutdownOnFrequentSigningFailure": true,
+  "ShutdownOnInternalFailure": true,
   "TLSServerName": "foo.example.com",
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",
@@ -14,7 +14,8 @@
     {"Endpoint": "/sig/ssh-user-cert", "Identifiers": ["key3"], "MaxValidity": 36000},
     {"Endpoint": "/sig/blob", "Identifiers": ["key1"], "MaxValidity": 36000}
   ],
-  "ShutdownOnSigningFailureCriteria": {
+  "ShutdownOnInternalFailureCriteria": {
+    "ReportMode": true,
     "ConsecutiveCountLimit": 3,
     "TimerDurationSecond": 120,
     "TimerCountLimit": 20

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -1,4 +1,4 @@
-package server
+package interceptor
 
 import (
 	"context"

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -1,4 +1,4 @@
-package server
+package interceptor
 
 import (
 	"context"

--- a/server/interceptor/shutdown.go
+++ b/server/interceptor/shutdown.go
@@ -1,0 +1,124 @@
+package interceptor
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc/codes"
+)
+
+// ShutdownCounterConfig configures the behavior of ShutdownCounter
+type ShutdownCounterConfig struct {
+	ReportOnly            bool
+	ConsecutiveCountLimit int32
+	TimeRangeCountLimit   int32
+	TickerDuration        time.Duration
+
+	// The function is provided by users to shutdown the server. This function is
+	// guaranteed to run only once.
+	ShutdownFn func()
+}
+
+// ShutdownCounter provides an interceptor function that can be used with
+// StatusInterceptor to shutdown the server when the criteria meet.
+type ShutdownCounter struct {
+	config ShutdownCounterConfig
+
+	// consecutiveCounter keeps track of the number of consecutive failures with
+	// Internal grpc code.
+	consecutiveCounter int32
+
+	// timeRangeCounter counts the number of failures with Internal grpc code in
+	// the most recent 1 minutes.
+	timeRangeCounter int32
+
+	// once ensures that the shutdown function only runs once.
+	once sync.Once
+}
+
+func (c *ShutdownCounter) shutdown() {
+	c.once.Do(func() {
+		if c.config.ShutdownFn != nil {
+			c.config.ShutdownFn()
+		}
+	})
+}
+
+func (c *ShutdownCounter) startTicker(ctx context.Context) {
+	timer := time.NewTicker(c.config.TickerDuration)
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+
+		case <-timer.C:
+			if c.timeRangeCounter >= c.config.TimeRangeCountLimit {
+				log.Printf("the number of internal failures %d reaches configured limit %d in %s",
+					c.timeRangeCounter, c.config.TimeRangeCountLimit, c.config.TickerDuration)
+
+				if c.config.ReportOnly {
+					log.Printf("ShutdownCounter: report only")
+				} else {
+					log.Printf("ShutdownCounter: shutting down server")
+					go c.shutdown()
+					timer.Stop()
+					return
+				}
+			}
+			// reset counter
+			atomic.StoreInt32(&c.timeRangeCounter, 0)
+		}
+	}
+}
+
+// InterceptorFn is intended to be used to create a StatusInterceptor to
+// monitor service status and shutdown the server when the criteria meet.
+//
+// 		shutdownCounterConfig := interceptor.ShutdownCounterConfig{
+//			ReportOnly:            true,
+//			ConsecutiveCountLimit: 4,
+//			TimeRangeCountLimit:   10,
+//			TickerDuration:        60 * time.Second,
+//			ShutdownFn: func() {
+//				grpcServer.GracefulStop()
+//				if err := server.Shutdown(ctx); err != nil {
+//					log.Fatalf("failed to shutdown server: %v", err)
+//				}
+//			},
+//		}
+//		interceptors = []grpc.UnaryServerInterceptor{
+//			interceptor.StatusInterceptor((interceptor.NewShutdownCounter(ctx, shutdownCounterConfig)).InterceptorFn),
+//		}
+func (c *ShutdownCounter) InterceptorFn(code codes.Code) {
+	if code == codes.Internal {
+		atomic.AddInt32(&c.consecutiveCounter, 1)
+		atomic.AddInt32(&c.timeRangeCounter, 1)
+	} else {
+		// reset counter
+		atomic.StoreInt32(&c.consecutiveCounter, 0)
+	}
+	if c.consecutiveCounter >= c.config.ConsecutiveCountLimit {
+		log.Printf("the number of consecutive internal failures %d reaches configured limit %d",
+			c.consecutiveCounter, c.config.ConsecutiveCountLimit)
+
+		if c.config.ReportOnly {
+			log.Printf("ShutdownCounter: report only")
+		} else {
+			log.Printf("ShutdownCounter: shutting down server")
+			go c.shutdown()
+		}
+	}
+}
+
+// NewShutdownCounter returns a ShutdownCounter.
+func NewShutdownCounter(ctx context.Context, config ShutdownCounterConfig) *ShutdownCounter {
+	counter := &ShutdownCounter{
+		config: config,
+	}
+	go counter.startTicker(ctx)
+	return counter
+}

--- a/server/interceptor_test.go
+++ b/server/interceptor_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestStatusInterceptor(t *testing.T) {
+	t.Parallel()
+
 	table := map[string]struct {
 		err      error
 		wantCode codes.Code

--- a/server/server.go
+++ b/server/server.go
@@ -365,7 +365,7 @@ func (c *shutdownCounter) interceptor(code codes.Code) {
 		atomic.StoreInt32(&c.consecutiveCounter, 0)
 	}
 	if c.consecutiveCounter >= c.config.consecutiveCountLimit {
-		log.Printf("the number of consecutive internal failures %d reaches configured limit %d",
+		log.Printf("the number of consecutive internal failures %d reached configured limit %d",
 			c.consecutiveCounter, c.config.consecutiveCountLimit)
 
 		if c.config.reportOnly {


### PR DESCRIPTION
This PR follows #45 to
1. Change the names `ShutdownOnFrequentSigningFailure` and `ShutdownOnSigningFailureCriteria` to `ShutdownOnInternalFailure` and `ShutdownOnInternalFailureCriteria`, respectively.
2. Add `ReportMode` that disables the shutdown operation, but still reports such events through logging.
3. Create `server/interceptor` package and update APIs (export methods, add context into the function signature, etc.)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
