### PR TITLE
Testing on Go 1.15

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.14.x', '1.13.x' ]
+        go: [ '1.15.x', '1.14.x', '1.13.x' ]
     name: Go ${{ matrix.go }} build
     steps:
       - name: checkout


### PR DESCRIPTION
Go 1.15 is out in this week. It's added into the matrix for tests.

***
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
