### PR TITLE
Skip processing requests that are cancelled/timed out

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -57,17 +57,19 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// if client cancelled the request or request timed out, we should skip processing
+	select {
+	case <-ctx.Done():
+		statusCode = http.StatusServiceUnavailable
+		err = fmt.Errorf("%s for request %q for %q", ctx.Err(), keyMeta.Identifier, config.BlobEndpoint)
+		return nil, status.Errorf(codes.Canceled, "Bad request: %v", err)
+	default:
+	}
+
 	if !s.KeyUsages[config.BlobEndpoint][keyMeta.Identifier] {
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("cannot use key %q for %q", keyMeta.Identifier, config.BlobEndpoint)
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
-	}
-
-	// ctx can have an error only when client cancels or request has timed out.
-	if err := ctx.Err(); err != nil {
-		statusCode = http.StatusServiceUnavailable
-		err = fmt.Errorf("%s for request %q", ctx.Err(), config.BlobEndpoint)
-		return nil, status.Errorf(codes.Canceled, "Abandoning request: %v", err)
 	}
 
 	key, err := s.GetBlobSigningPublicKey(keyMeta.Identifier)
@@ -98,6 +100,15 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// if client cancelled the request or request timed out, we should skip processing
+	select {
+	case <-ctx.Done():
+		statusCode = http.StatusServiceUnavailable
+		err = fmt.Errorf("%s for request %q for %q", ctx.Err(), request.KeyMeta.Identifier, config.BlobEndpoint)
+		return nil, status.Errorf(codes.Canceled, "Bad request: %v", err)
+	default:
+	}
+
 	if !s.KeyUsages[config.BlobEndpoint][request.KeyMeta.Identifier] {
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("cannot use key %q for %q", request.KeyMeta.Identifier, config.BlobEndpoint)
@@ -112,13 +123,6 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 	if len(digest) > maxDigestLen {
 		statusCode = http.StatusBadRequest
 		return nil, status.Error(codes.InvalidArgument, "Bad request: digest length too long")
-	}
-
-	// If client disconnects or has timed out, we do not need to process the request.
-	if err := ctx.Err(); err != nil {
-		statusCode = http.StatusServiceUnavailable
-		err = fmt.Errorf("%s for request %q", ctx.Err(), config.BlobEndpoint)
-		return nil, status.Errorf(codes.Canceled, "Abandoning request: %v", err)
 	}
 
 	signerOpts := getSignerOpts(request.HashAlgorithm.String())

--- a/api/blob_test.go
+++ b/api/blob_test.go
@@ -143,8 +143,7 @@ func TestGetBlobSigningKey(t *testing.T) {
 		if tt.timeout != 0 {
 			timeout = tt.timeout
 		}
-		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -171,6 +170,7 @@ func TestGetBlobSigningKey(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }
 
@@ -249,8 +249,7 @@ func TestPostSignBlob(t *testing.T) {
 		if tt.timeout != 0 {
 			timeout = tt.timeout
 		}
-		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -280,5 +279,6 @@ func TestPostSignBlob(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }

--- a/api/sshhost_test.go
+++ b/api/sshhost_test.go
@@ -129,7 +129,7 @@ func TestGetHostSSHCertificateSigningKey(t *testing.T) {
 			timeout = tt.timeout
 		}
 		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -156,6 +156,7 @@ func TestGetHostSSHCertificateSigningKey(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }
 
@@ -323,7 +324,7 @@ func TestPostHostSSHCertificate(t *testing.T) {
 			timeout = tt.timeout
 		}
 		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -353,5 +354,6 @@ func TestPostHostSSHCertificate(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }

--- a/api/sshhost_test.go
+++ b/api/sshhost_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/theparanoids/crypki/config"
@@ -73,9 +74,11 @@ func TestGetHostSSHCertificateAvailableSigningKeys(t *testing.T) {
 
 func TestGetHostSSHCertificateSigningKey(t *testing.T) {
 	t.Parallel()
+	defaultTimeout := time.Second
 	testcases := map[string]struct {
 		KeyUsages map[string]map[string]bool
 		KeyMeta   *proto.KeyMeta
+		timeout   time.Duration
 		// if expectedSSHKey set to nil, we are expecting an error while testing
 		expectedSSHKey *proto.SSHKey
 	}{
@@ -111,13 +114,24 @@ func TestGetHostSSHCertificateSigningKey(t *testing.T) {
 			KeyMeta:        &proto.KeyMeta{Identifier: "sshhostid2"},
 			expectedSSHKey: nil,
 		},
+		"requestTimeout": {
+			KeyUsages:      combineKeyUsage,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshhostid1"},
+			timeout:        10 * time.Microsecond,
+			expectedSSHKey: nil,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		timeout := defaultTimeout
+		if tt.timeout != 0 {
+			timeout = tt.timeout
+		}
+		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
+		ctx, _ := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: true}
 			ssBad := initMockSigningService(msspBad)
@@ -148,6 +162,7 @@ func TestGetHostSSHCertificateSigningKey(t *testing.T) {
 func TestPostHostSSHCertificate(t *testing.T) {
 	t.Parallel()
 	defaultMaxValidity := map[string]uint64{config.X509CertEndpoint: 0}
+	defaultTimeout := time.Second
 	testcases := map[string]struct {
 		KeyUsages   map[string]map[string]bool
 		maxValidity map[string]uint64
@@ -157,6 +172,7 @@ func TestPostHostSSHCertificate(t *testing.T) {
 		expectedSSHKey *proto.SSHKey
 		PubKey         string
 		KeyID          string
+		timeout        time.Duration
 	}{
 		"emptyKeyUsages": {
 			KeyMeta:        &proto.KeyMeta{Identifier: "randomid"},
@@ -288,13 +304,28 @@ func TestPostHostSSHCertificate(t *testing.T) {
 			PubKey:         testGoodRsaPubKey,
 			KeyID:          testGoodKeyID,
 		},
+		"request timeout": {
+			KeyUsages:      sshkeyUsage,
+			maxValidity:    map[string]uint64{config.SSHHostCertEndpoint: 3600},
+			validity:       3600,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshhostid"},
+			expectedSSHKey: nil,
+			PubKey:         testGoodRsaPubKey,
+			KeyID:          testGoodKeyID,
+			timeout:        10 * time.Microsecond,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		timeout := defaultTimeout
+		if tt.timeout != 0 {
+			timeout = tt.timeout
+		}
+		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
+		ctx, _ := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: true}
 			ssBad := initMockSigningService(msspBad)

--- a/api/sshuser_test.go
+++ b/api/sshuser_test.go
@@ -129,7 +129,7 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 			timeout = tt.timeout
 		}
 		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -156,6 +156,7 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }
 
@@ -323,7 +324,7 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			timeout = tt.timeout
 		}
 		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -353,5 +354,6 @@ func TestPostUserSSHCertificate(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }

--- a/api/sshuser_test.go
+++ b/api/sshuser_test.go
@@ -74,11 +74,13 @@ func TestGetUserSSHCertificateAvailableSigningKeys(t *testing.T) {
 
 func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 	t.Parallel()
-	defaultTimeout := time.Second
+	defaultCtx := context.Background()
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx       context.Context
 		KeyUsages map[string]map[string]bool
 		KeyMeta   *proto.KeyMeta
-		timeout   time.Duration
 		// if expectedSSHKey set to nil, we are expecting an error while testing
 		expectedSSHKey *proto.SSHKey
 	}{
@@ -115,34 +117,31 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 			expectedSSHKey: nil,
 		},
 		"requestTimeout": {
+			ctx:            ctxTimeout,
 			KeyUsages:      combineKeyUsage,
 			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid1"},
-			timeout:        10 * time.Microsecond,
 			expectedSSHKey: nil,
 		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
-		timeout := defaultTimeout
-		if tt.timeout != 0 {
-			timeout = tt.timeout
-		}
-		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			if tt.ctx == nil {
+				tt.ctx = defaultCtx
+			}
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: true}
 			ssBad := initMockSigningService(msspBad)
-			_, err := ssBad.GetUserSSHCertificateSigningKey(ctx, tt.KeyMeta)
+			_, err := ssBad.GetUserSSHCertificateSigningKey(tt.ctx, tt.KeyMeta)
 			if err == nil {
 				t.Fatalf("in test %v: bad signing service should return error but got nil", label)
 			}
 			// good certsign
 			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: false}
 			ssGood := initMockSigningService(msspGood)
-			key, err := ssGood.GetUserSSHCertificateSigningKey(ctx, tt.KeyMeta)
+			key, err := ssGood.GetUserSSHCertificateSigningKey(tt.ctx, tt.KeyMeta)
 			if err != nil && tt.expectedSSHKey != nil {
 				t.Fatalf("in test %v: not expecting error but got error %v", label, err)
 			}
@@ -156,15 +155,17 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 				}
 			}
 		})
-		cancel()
 	}
 }
 
 func TestPostUserSSHCertificate(t *testing.T) {
 	t.Parallel()
 	defaultMaxValidity := map[string]uint64{config.SSHUserCertEndpoint: 0}
-	defaultTimeout := time.Second
+	defaultCtx := context.Background()
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		KeyUsages   map[string]map[string]bool
 		maxValidity map[string]uint64
 		validity    uint64
@@ -173,7 +174,6 @@ func TestPostUserSSHCertificate(t *testing.T) {
 		expectedSSHKey *proto.SSHKey
 		PubKey         string
 		KeyID          string
-		timeout        time.Duration
 	}{
 		"emptyKeyUsages": {
 			KeyMeta:        &proto.KeyMeta{Identifier: "randomid"},
@@ -306,6 +306,7 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			KeyID:          testGoodKeyID,
 		},
 		"request timeout": {
+			ctx:            ctxTimeout,
 			KeyUsages:      sshkeyUsage,
 			maxValidity:    map[string]uint64{config.SSHUserCertEndpoint: 3600},
 			validity:       3600,
@@ -313,25 +314,21 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			expectedSSHKey: nil,
 			PubKey:         testGoodRsaPubKey,
 			KeyID:          testGoodKeyID,
-			timeout:        10 * time.Microsecond,
 		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
-		timeout := defaultTimeout
-		if tt.timeout != 0 {
-			timeout = tt.timeout
-		}
-		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			if tt.ctx == nil {
+				tt.ctx = defaultCtx
+			}
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: true}
 			ssBad := initMockSigningService(msspBad)
 			requestBad := &proto.SSHCertificateSigningRequest{KeyMeta: tt.KeyMeta, PublicKey: tt.PubKey, Validity: tt.validity, KeyId: tt.KeyID}
-			_, err := ssBad.PostUserSSHCertificate(ctx, requestBad)
+			_, err := ssBad.PostUserSSHCertificate(tt.ctx, requestBad)
 			if err == nil {
 				t.Fatalf("in test %v: bad signing service should return error but got nil", label)
 			}
@@ -340,7 +337,7 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: false}
 			ssGood := initMockSigningService(msspGood)
 			requestGood := &proto.SSHCertificateSigningRequest{KeyMeta: tt.KeyMeta, PublicKey: tt.PubKey, Validity: tt.validity, KeyId: tt.KeyID}
-			cert, err := ssGood.PostUserSSHCertificate(ctx, requestGood)
+			cert, err := ssGood.PostUserSSHCertificate(tt.ctx, requestGood)
 			if tt.expectedSSHKey == nil {
 				if err == nil {
 					t.Errorf("expected error for invalid test %v, got nil", label)
@@ -354,6 +351,5 @@ func TestPostUserSSHCertificate(t *testing.T) {
 				}
 			}
 		})
-		cancel()
 	}
 }

--- a/api/sshuser_test.go
+++ b/api/sshuser_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/theparanoids/crypki/config"
@@ -73,9 +74,11 @@ func TestGetUserSSHCertificateAvailableSigningKeys(t *testing.T) {
 
 func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 	t.Parallel()
+	defaultTimeout := time.Second
 	testcases := map[string]struct {
 		KeyUsages map[string]map[string]bool
 		KeyMeta   *proto.KeyMeta
+		timeout   time.Duration
 		// if expectedSSHKey set to nil, we are expecting an error while testing
 		expectedSSHKey *proto.SSHKey
 	}{
@@ -111,13 +114,24 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid2"},
 			expectedSSHKey: nil,
 		},
+		"requestTimeout": {
+			KeyUsages:      combineKeyUsage,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid1"},
+			timeout:        10 * time.Microsecond,
+			expectedSSHKey: nil,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		timeout := defaultTimeout
+		if tt.timeout != 0 {
+			timeout = tt.timeout
+		}
+		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
+		ctx, _ := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: true}
 			ssBad := initMockSigningService(msspBad)
@@ -148,6 +162,7 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 func TestPostUserSSHCertificate(t *testing.T) {
 	t.Parallel()
 	defaultMaxValidity := map[string]uint64{config.SSHUserCertEndpoint: 0}
+	defaultTimeout := time.Second
 	testcases := map[string]struct {
 		KeyUsages   map[string]map[string]bool
 		maxValidity map[string]uint64
@@ -157,6 +172,7 @@ func TestPostUserSSHCertificate(t *testing.T) {
 		expectedSSHKey *proto.SSHKey
 		PubKey         string
 		KeyID          string
+		timeout        time.Duration
 	}{
 		"emptyKeyUsages": {
 			KeyMeta:        &proto.KeyMeta{Identifier: "randomid"},
@@ -288,13 +304,28 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			PubKey:         testGoodRsaPubKey,
 			KeyID:          testGoodKeyID,
 		},
+		"request timeout": {
+			KeyUsages:      sshkeyUsage,
+			maxValidity:    map[string]uint64{config.SSHUserCertEndpoint: 3600},
+			validity:       3600,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid"},
+			expectedSSHKey: nil,
+			PubKey:         testGoodRsaPubKey,
+			KeyID:          testGoodKeyID,
+			timeout:        10 * time.Microsecond,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		timeout := defaultTimeout
+		if tt.timeout != 0 {
+			timeout = tt.timeout
+		}
+		// the cancel function returned by WithTimeout should be called, not discarded, to avoid a context leak
+		ctx, _ := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
 			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: true}
 			ssBad := initMockSigningService(msspBad)

--- a/api/x509cert_test.go
+++ b/api/x509cert_test.go
@@ -129,7 +129,7 @@ func TestGetX509CACertificate(t *testing.T) {
 		if tt.timeout != 0 {
 			timeout = tt.timeout
 		}
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -156,6 +156,7 @@ func TestGetX509CACertificate(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }
 
@@ -300,7 +301,7 @@ func TestPostX509Certificate(t *testing.T) {
 		if tt.timeout != 0 {
 			timeout = tt.timeout
 		}
-		ctx, _ := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 			// bad certsign should return error anyways
@@ -329,5 +330,6 @@ func TestPostX509Certificate(t *testing.T) {
 				}
 			}
 		})
+		cancel()
 	}
 }


### PR DESCRIPTION
Before processing or doing time intensive task on server, make sure client has not cancelled the request or the request has not timed out on the server.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
