### PR TITLE
Cancel server request when client cancels

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -63,7 +63,7 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	key, err := s.GetBlobSigningPublicKey(keyMeta.Identifier)
+	key, err := s.GetBlobSigningPublicKey(ctx, keyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")
@@ -108,7 +108,7 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 	}
 
 	signerOpts := getSignerOpts(request.HashAlgorithm.String())
-	signature, err := s.SignBlob(digest, signerOpts, request.KeyMeta.Identifier)
+	signature, err := s.SignBlob(ctx, digest, signerOpts, request.KeyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/theparanoids/crypki"
 	"github.com/theparanoids/crypki/config"
@@ -82,6 +83,7 @@ type mockSigningServiceParam struct {
 	KeyUsages   map[string]map[string]bool
 	MaxValidity map[string]uint64
 	sendError   bool
+	timeout     time.Duration
 }
 
 type mockBadCertSign struct {
@@ -138,6 +140,7 @@ func initMockSigningService(mssp mockSigningServiceParam) *SigningService {
 	} else {
 		ss.CertSign = &mockGoodCertSign{}
 	}
+	time.Sleep(mssp.timeout)
 	return ss
 }
 

--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"errors"
@@ -95,7 +96,7 @@ func (mbcs *mockBadCertSign) SignSSHCert(cert *ssh.Certificate, keyIdentifier st
 func (mbcs *mockBadCertSign) GetX509CACert(keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignX509Cert(cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {
@@ -117,7 +118,7 @@ func (mgcs *mockGoodCertSign) SignSSHCert(cert *ssh.Certificate, keyIdentifier s
 func (mgcs *mockGoodCertSign) GetX509CACert(keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 ca cert"), nil
 }
-func (mgcs *mockGoodCertSign) SignX509Cert(cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 cert"), nil
 }
 func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {

--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -87,44 +87,44 @@ type mockSigningServiceParam struct {
 type mockBadCertSign struct {
 }
 
-func (mbcs *mockBadCertSign) GetSSHCertSigningKey(keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) GetX509CACert(keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 
 type mockGoodCertSign struct {
 }
 
-func (mgcs *mockGoodCertSign) GetSSHCertSigningKey(keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good ssh signing key"), nil
 }
-func (mgcs *mockGoodCertSign) SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
 	return []byte("good ssh cert"), nil
 }
-func (mgcs *mockGoodCertSign) GetX509CACert(keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 ca cert"), nil
 }
 func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 cert"), nil
 }
-func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good blob signing key"), nil
 }
-func (mgcs *mockGoodCertSign) SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
 	return []byte("good blob signature"), nil
 }
 

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -63,7 +63,7 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	key, err := s.GetSSHCertSigningKey(keyMeta.Identifier)
+	key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")
@@ -113,7 +113,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	data, err := s.SignSSHCert(cert, request.KeyMeta.Identifier)
+	data, err := s.SignSSHCert(ctx, cert, request.KeyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -63,7 +63,7 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	key, err := s.GetSSHCertSigningKey(keyMeta.Identifier)
+	key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")
@@ -113,7 +113,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	data, err := s.SignSSHCert(cert, request.KeyMeta.Identifier)
+	data, err := s.SignSSHCert(ctx, cert, request.KeyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -143,6 +143,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		switch reqCtx.Err() {
 		case context.DeadlineExceeded:
 			err = fmt.Errorf("request timed out for %q", config.X509CertEndpoint)
+			return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 		case context.Canceled:
 			err = fmt.Errorf("client cancelled request for %q", config.X509CertEndpoint)
 		}

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -126,12 +126,12 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	case <-ctx.Done():
 		// client canceled the request. Cancel any pending server request and return
 		cancel()
-		statusCode = http.StatusInternalServerError
+		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("client canceled request for %q", config.X509CertEndpoint)
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// server request timed out.
-		statusCode = http.StatusGatewayTimeout
+		statusCode = http.StatusServiceUnavailable
 		err = fmt.Errorf("request timed out for %q", config.X509CertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -56,6 +56,13 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// ctx can have an error only when client cancels or request has timed out.
+	if err := ctx.Err(); err != nil {
+		statusCode = http.StatusBadRequest
+		err = fmt.Errorf("%s for request %q", ctx.Err(), config.X509CertEndpoint)
+		return nil, status.Errorf(codes.Canceled, "Abandoning request: %v", err)
+	}
+
 	if !s.KeyUsages[config.X509CertEndpoint][keyMeta.Identifier] {
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("cannot use key %q for %q", keyMeta.Identifier, config.X509CertEndpoint)
@@ -89,6 +96,13 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// If client disconnects or has timed out, we do not need to process the request.
+	if err := ctx.Err(); err != nil {
+		statusCode = http.StatusServiceUnavailable
+		err = fmt.Errorf("%s for request %q", ctx.Err(), config.X509CertEndpoint)
+		return nil, status.Errorf(codes.Canceled, "Abandoning request: %v", err)
+	}
+
 	maxValidity := s.MaxValidity[config.X509CertEndpoint]
 	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {
 		statusCode = http.StatusBadRequest
@@ -108,7 +122,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	data, err := s.SignX509Cert(req, request.KeyMeta.Identifier)
+	data, err := s.SignX509Cert(ctx, req, request.KeyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -104,7 +104,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		// canceled automatically when the timeout expires.
 		reqCtx, cancel = context.WithTimeout(ctx, time.Until(elapsed))
 	} else {
-		reqCtx, cancel = context.WithCancel(ctx)
+		reqCtx, cancel = context.WithTimeout(ctx, config.DefaultRequestTimeout)
 	}
 	defer cancel() // Cancel ctx as soon as PostX509Certificate returns
 

--- a/api/x509cert_test.go
+++ b/api/x509cert_test.go
@@ -274,7 +274,7 @@ func TestPostX509Certificate(t *testing.T) {
 			expectedCert: nil,
 			CSR:          testGoodcsrRsa,
 		},
-		"x509 request timeout": {
+		"requestTimeout": {
 			ctx:          timeoutCtx,
 			KeyUsages:    combineKeyUsage,
 			maxValidity:  map[string]uint64{config.X509CertEndpoint: 3600},

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/theparanoids/crypki"
 )
@@ -39,6 +40,8 @@ const (
 	SSHHostCertEndpoint = "/sig/ssh-host-cert"
 	// BlobEndpoint specifies the endpoint for raw signing.
 	BlobEndpoint = "/sig/blob"
+	// DefaultRequestTimeout specifies the max time required by HSM to sign a cert.
+	DefaultRequestTimeout = 5 * time.Second
 )
 
 var endpoints = map[string]bool{

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,8 @@ const (
 	SSHHostCertEndpoint = "/sig/ssh-host-cert"
 	// BlobEndpoint specifies the endpoint for raw signing.
 	BlobEndpoint = "/sig/blob"
-	// DefaultRequestTimeout specifies the max time required by HSM to sign a cert.
-	DefaultRequestTimeout = 5 * time.Second
+	// DefaultPKCS11Timeout specifies the max time required by HSM to sign a cert.
+	DefaultPKCS11Timeout = 5 * time.Second
 )
 
 var endpoints = map[string]bool{

--- a/crypki.go
+++ b/crypki.go
@@ -46,17 +46,17 @@ const (
 // CertSign interface contains methods related to signing certificates.
 type CertSign interface {
 	// GetSSHCertSigningKey returns the SSH signing key of the specified key.
-	GetSSHCertSigningKey(keyIdentifier string) ([]byte, error)
+	GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignSSHCert returns an SSH cert signed by the specified key.
-	SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byte, error)
+	SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error)
 	// GetX509CACert returns the X509 CA cert of the specified key.
-	GetX509CACert(keyIdentifier string) ([]byte, error)
+	GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignX509Cert returns an x509 cert signed by the specified key.
 	SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error)
 	// GetBlobSigningPublicKey returns the public signing key of the specified key that signs the user's data.
-	GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error)
+	GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignBlob returns a signature signed by the specified key.
-	SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error)
+	SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error)
 }
 
 // CAConfig represents the configuration params for generating the CA certificate.

--- a/crypki.go
+++ b/crypki.go
@@ -4,6 +4,7 @@
 package crypki
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 
@@ -51,7 +52,7 @@ type CertSign interface {
 	// GetX509CACert returns the X509 CA cert of the specified key.
 	GetX509CACert(keyIdentifier string) ([]byte, error)
 	// SignX509Cert returns an x509 cert signed by the specified key.
-	SignX509Cert(cert *x509.Certificate, keyIdentifier string) ([]byte, error)
+	SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error)
 	// GetBlobSigningPublicKey returns the public signing key of the specified key that signs the user's data.
 	GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error)
 	// SignBlob returns a signature signed by the specified key.

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -39,7 +39,7 @@ type signer struct {
 }
 
 // NewCertSign initializes a CertSign object that interacts with PKCS11 compliant device.
-func NewCertSign(pkcs11ModulePath string, keys []config.KeyConfig, requireX509CACert map[string]bool, hostname string, ips []net.IP) (crypki.CertSign, error) {
+func NewCertSign(ctx context.Context, pkcs11ModulePath string, keys []config.KeyConfig, requireX509CACert map[string]bool, hostname string, ips []net.IP) (crypki.CertSign, error) {
 	p11ctx, err := initPKCS11Context(pkcs11ModulePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize PKCS11 context: %v", err)
@@ -63,7 +63,7 @@ func NewCertSign(pkcs11ModulePath string, keys []config.KeyConfig, requireX509CA
 		s.sPool[key.Identifier] = pool
 		// Initialize x509 CA cert if this key will be used for signing x509 certs.
 		if requireX509CACert[key.Identifier] {
-			cert, err := getX509CACert(key, pool, hostname, ips)
+			cert, err := getX509CACert(ctx, key, pool, hostname, ips)
 			if err != nil {
 				log.Fatalf("failed to get x509 CA cert for key with identifier %q, err: %v", key.Identifier, err)
 			}
@@ -74,12 +74,15 @@ func NewCertSign(pkcs11ModulePath string, keys []config.KeyConfig, requireX509CA
 	return s, nil
 }
 
-func (s *signer) GetSSHCertSigningKey(keyIdentifier string) ([]byte, error) {
+func (s *signer) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 
 	sshSigner, err := ssh.NewSignerFromSigner(signer)
@@ -89,7 +92,7 @@ func (s *signer) GetSSHCertSigningKey(keyIdentifier string) ([]byte, error) {
 	return ssh.MarshalAuthorizedKey(sshSigner.PublicKey()), nil
 }
 
-func (s *signer) SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (s *signer) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
 	const methodName = "SignSSHCert"
 	start := time.Now()
 	var ht int64
@@ -105,7 +108,10 @@ func (s *signer) SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byt
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 
 	sshSigner, err := ssh.NewSignerFromSigner(signer)
@@ -122,12 +128,15 @@ func (s *signer) SignSSHCert(cert *ssh.Certificate, keyIdentifier string) ([]byt
 	return bytes.TrimSpace(ssh.MarshalAuthorizedKey(cert)), nil
 }
 
-func (s *signer) GetX509CACert(keyIdentifier string) ([]byte, error) {
+func (s *signer) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 
 	cert, ok := s.x509CACerts[keyIdentifier]
@@ -154,7 +163,10 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("client request timed out, skip signing cert")
+	}
 	defer pool.put(signer)
 	cert.SignatureAlgorithm = getSignatureAlgorithm(signer.signAlgorithm())
 	// measure time taken by hsm
@@ -168,12 +180,15 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert}), nil
 }
 
-func (s *signer) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {
+func (s *signer) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 	pk, err := x509.MarshalPKIXPublicKey(signer.Public())
 	if err != nil {
@@ -183,7 +198,7 @@ func (s *signer) GetBlobSigningPublicKey(keyIdentifier string) ([]byte, error) {
 	return pem.EncodeToMemory(b), nil
 }
 
-func (s *signer) SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (s *signer) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
 	const methodName = "SignBlob"
 	start := time.Now()
 	var ht int64
@@ -199,7 +214,10 @@ func (s *signer) SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier s
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 
 	// measure time taken by hsm
@@ -216,7 +234,7 @@ func (s *signer) SignBlob(digest []byte, opts crypto.SignerOpts, keyIdentifier s
 // getX509CACert reads and returns x509 CA certificate from X509CACertLocation.
 // If the certificate is not valid, and CreateCACertIfNotExist is true, a new CA
 // certificate will be generated based on the config, and wrote to X509CACertLocation.
-func getX509CACert(key config.KeyConfig, pool sPool, hostname string, ips []net.IP) (*x509.Certificate, error) {
+func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostname string, ips []net.IP) (*x509.Certificate, error) {
 	// Try parse certificate in the given location.
 	if certBytes, err := ioutil.ReadFile(key.X509CACertLocation); err == nil {
 		block, _ := pem.Decode(certBytes)
@@ -235,7 +253,10 @@ func getX509CACert(key config.KeyConfig, pool sPool, hostname string, ips []net.
 		return nil, errors.New("unable to get x509 CA certificate, but CreateCACertIfNotExist is set to false")
 	}
 	// Create x509 CA cert.
-	signer := pool.get()
+	signer, err := pool.get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defer pool.put(signer)
 
 	caConfig := &crypki.CAConfig{

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -14,9 +14,6 @@ import (
 	"net"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	p11 "github.com/miekg/pkcs11"
 	"golang.org/x/crypto/ssh"
 
@@ -160,13 +157,6 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	signer := pool.get()
 	defer pool.put(signer)
 	cert.SignatureAlgorithm = getSignatureAlgorithm(signer.signAlgorithm())
-
-	// check client has not timed out before making a request to hsm
-	if err := ctx.Err(); err != nil {
-		err := fmt.Errorf("client canceled request for signing x509 cert, %q", ctx.Err())
-		return nil, status.Errorf(codes.Canceled, "%v", err)
-	}
-
 	// measure time taken by hsm
 	hStart := time.Now()
 	signedCert, err := x509.CreateCertificate(rand.Reader, cert, s.x509CACerts[keyIdentifier], cert.PublicKey, signer)

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	defaultIdentifier = "dummy"
 	badIdentifier     = "unknown"
+	timeout           = 1 * time.Second
 )
 
 // enforce signer implements CertSign interface.
@@ -59,7 +60,7 @@ func initMockSigner(isBad bool) (*signer, error) {
 func TestGetSSHCertSigningKey(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	testcases := map[string]struct {
 		ctx         context.Context
@@ -153,7 +154,7 @@ func TestSignSSHCert(t *testing.T) {
 		Key:         ecPubKey,
 	}
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	testcases := map[string]struct {
 		ctx         context.Context
@@ -206,7 +207,7 @@ func TestSignSSHCert(t *testing.T) {
 func TestGetX509CACert(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	testcases := map[string]struct {
 		ctx         context.Context
@@ -291,7 +292,8 @@ func TestSignX509Cert(t *testing.T) {
 	}
 	cp.AddCert(caCert)
 
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	testcases := map[string]struct {
@@ -301,10 +303,10 @@ func TestSignX509Cert(t *testing.T) {
 		isBadSigner bool
 		expectError bool
 	}{
-		"cert-rsa-good-signer": {context.Background(), certRSA, defaultIdentifier, false, false},
-		"cert-ec-good-signer":  {context.Background(), certEC, defaultIdentifier, false, false},
-		"cert-bad-identifier":  {context.Background(), certRSA, badIdentifier, false, true},
-		"cert-bad-signer":      {context.Background(), certRSA, defaultIdentifier, true, true},
+		"cert-rsa-good-signer": {ctx, certRSA, defaultIdentifier, false, false},
+		"cert-ec-good-signer":  {ctx, certEC, defaultIdentifier, false, false},
+		"cert-bad-identifier":  {ctx, certRSA, badIdentifier, false, true},
+		"cert-bad-signer":      {ctx, certRSA, defaultIdentifier, true, true},
 		"cert-request-timeout": {timeoutCtx, certRSA, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
@@ -346,7 +348,7 @@ func TestSignX509Cert(t *testing.T) {
 func TestGetBlobSigningPublicKey(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	testcases := map[string]struct {
 		ctx         context.Context
@@ -354,10 +356,10 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-signer":    {ctx, defaultIdentifier, false, false},
-		"bad-identifier": {ctx, badIdentifier, false, true},
-		"bad-signer":     {ctx, defaultIdentifier, true, true},
-		"client-timeout": {timeoutCtx, defaultIdentifier, false, true},
+		"good-signer":         {ctx, defaultIdentifier, false, false},
+		"bad-identifier":      {ctx, badIdentifier, false, true},
+		"bad-signer":          {ctx, defaultIdentifier, true, true},
+		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
@@ -394,7 +396,7 @@ func TestSignBlob(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	testcases := map[string]struct {
 		ctx         context.Context

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -71,11 +71,12 @@ func TestGetSSHCertSigningKey(t *testing.T) {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetSSHCertSigningKey(tt.identifier)
+			_, err = signer.GetSSHCertSigningKey(ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -169,11 +170,12 @@ func TestSignSSHCert(t *testing.T) {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			data, err := signer.SignSSHCert(tt.cert, tt.identifier)
+			data, err := signer.SignSSHCert(ctx, tt.cert, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -211,11 +213,12 @@ func TestGetX509CACert(t *testing.T) {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetX509CACert(tt.identifier)
+			_, err = signer.GetX509CACert(ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -342,11 +345,12 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetBlobSigningPublicKey(tt.identifier)
+			_, err = signer.GetBlobSigningPublicKey(ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -392,11 +396,12 @@ func TestSignBlob(t *testing.T) {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			signature, err := signer.SignBlob(tt.digest, tt.opts, tt.identifier)
+			signature, err := signer.SignBlob(ctx, tt.digest, tt.opts, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -58,25 +58,29 @@ func initMockSigner(isBad bool) (*signer, error) {
 
 func TestGetSSHCertSigningKey(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-signer":    {defaultIdentifier, false, false},
-		"bad-identifier": {badIdentifier, false, true},
-		"bad-signer":     {defaultIdentifier, true, true},
+		"good-signer":         {ctx, defaultIdentifier, false, false},
+		"bad-identifier":      {ctx, badIdentifier, false, true},
+		"bad-signer":          {ctx, defaultIdentifier, true, true},
+		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetSSHCertSigningKey(ctx, tt.identifier)
+			_, err = signer.GetSSHCertSigningKey(tt.ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -99,9 +103,6 @@ func TestSignSSHCert(t *testing.T) {
 		t.Fatalf("unable to generate EC key: %v", err)
 	}
 	ecPubKey, _ := ssh.NewPublicKey(&eckey.PublicKey)
-	if err != nil {
-		t.Fatalf("unable to create ssh EC public key: %v", err)
-	}
 
 	exts := make(map[string]string)
 	exts["permit-pty"] = ""
@@ -151,31 +152,35 @@ func TestSignSSHCert(t *testing.T) {
 		ValidAfter:  uint64(now - 1000),
 		Key:         ecPubKey,
 	}
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		cert        *ssh.Certificate
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"host-cert-rsa":            {hostCertRSA, defaultIdentifier, false, false},
-		"host-cert-ec":             {hostCertEC, defaultIdentifier, false, false},
-		"host-cert-bad-identifier": {hostCertRSA, badIdentifier, false, true},
-		"host-cert-bad-signer":     {hostCertRSA, defaultIdentifier, true, true},
-		"user-cert-rsa":            {userCertRSA, defaultIdentifier, false, false},
-		"user-cert-ec":             {userCertEC, defaultIdentifier, false, false},
-		"user-cert-bad-identifier": {userCertRSA, badIdentifier, false, true},
-		"user-cert-bad-signer":     {userCertRSA, defaultIdentifier, true, true},
+		"host-cert-rsa":             {ctx, hostCertRSA, defaultIdentifier, false, false},
+		"host-cert-ec":              {ctx, hostCertEC, defaultIdentifier, false, false},
+		"host-cert-bad-identifier":  {ctx, hostCertRSA, badIdentifier, false, true},
+		"host-cert-bad-signer":      {ctx, hostCertRSA, defaultIdentifier, true, true},
+		"user-cert-rsa":             {ctx, userCertRSA, defaultIdentifier, false, false},
+		"user-cert-ec":              {ctx, userCertEC, defaultIdentifier, false, false},
+		"user-cert-bad-identifier":  {ctx, userCertRSA, badIdentifier, false, true},
+		"user-cert-bad-signer":      {ctx, userCertRSA, defaultIdentifier, true, true},
+		"user-cert-request-timeout": {timeoutCtx, userCertRSA, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			data, err := signer.SignSSHCert(ctx, tt.cert, tt.identifier)
+			data, err := signer.SignSSHCert(tt.ctx, tt.cert, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -200,25 +205,29 @@ func TestSignSSHCert(t *testing.T) {
 
 func TestGetX509CACert(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-signer":    {defaultIdentifier, false, false},
-		"bad-identifier": {badIdentifier, false, true},
-		"bad-signer":     {defaultIdentifier, true, false},
+		"good-signer":         {ctx, defaultIdentifier, false, false},
+		"bad-identifier":      {ctx, badIdentifier, false, true},
+		"bad-signer":          {ctx, defaultIdentifier, true, false},
+		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetX509CACert(ctx, tt.identifier)
+			_, err = signer.GetX509CACert(tt.ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -282,27 +291,31 @@ func TestSignX509Cert(t *testing.T) {
 	}
 	cp.AddCert(caCert)
 
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+	defer cancel()
+
 	testcases := map[string]struct {
+		ctx         context.Context
 		cert        *x509.Certificate
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"cert-rsa-good-signer": {certRSA, defaultIdentifier, false, false},
-		"cert-ec-good-signer":  {certEC, defaultIdentifier, false, false},
-		"cert-bad-identifier":  {certRSA, badIdentifier, false, true},
-		"cert-bad-signer":      {certRSA, defaultIdentifier, true, true},
+		"cert-rsa-good-signer": {context.Background(), certRSA, defaultIdentifier, false, false},
+		"cert-ec-good-signer":  {context.Background(), certEC, defaultIdentifier, false, false},
+		"cert-bad-identifier":  {context.Background(), certRSA, badIdentifier, false, true},
+		"cert-bad-signer":      {context.Background(), certRSA, defaultIdentifier, true, true},
+		"cert-request-timeout": {timeoutCtx, certRSA, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			data, err := signer.SignX509Cert(ctx, tt.cert, tt.identifier)
+			data, err := signer.SignX509Cert(tt.ctx, tt.cert, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -332,25 +345,29 @@ func TestSignX509Cert(t *testing.T) {
 
 func TestGetBlobSigningPublicKey(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-signer":    {defaultIdentifier, false, false},
-		"bad-identifier": {badIdentifier, false, true},
-		"bad-signer":     {defaultIdentifier, true, true},
+		"good-signer":    {ctx, defaultIdentifier, false, false},
+		"bad-identifier": {ctx, badIdentifier, false, true},
+		"bad-signer":     {ctx, defaultIdentifier, true, true},
+		"client-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			_, err = signer.GetBlobSigningPublicKey(ctx, tt.identifier)
+			_, err = signer.GetBlobSigningPublicKey(tt.ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -376,32 +393,36 @@ func TestSignBlob(t *testing.T) {
 		t.Fatalf("unable to parse private key: %v", err)
 	}
 
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		digest      []byte
 		opts        crypto.SignerOpts
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-SHA224":    {goodDigestSHA224[:], crypto.SHA224, defaultIdentifier, false, false},
-		"good-SHA256":    {goodDigestSHA256[:], crypto.SHA256, defaultIdentifier, false, false},
-		"good-SHA384":    {goodDigestSHA384[:], crypto.SHA384, defaultIdentifier, false, false},
-		"good-SHA512":    {goodDigestSHA512[:], crypto.SHA512, defaultIdentifier, false, false},
-		"bad-digest":     {[]byte("bad digest"), crypto.SHA256, defaultIdentifier, false, true},
-		"bad-wrong-hash": {goodDigestSHA224[:], crypto.SHA256, defaultIdentifier, false, true},
-		"bad-identifier": {goodDigestSHA224[:], crypto.SHA256, badIdentifier, false, true},
-		"bad-signer":     {goodDigestSHA224[:], crypto.SHA256, defaultIdentifier, true, true},
+		"good-SHA224":         {ctx, goodDigestSHA224[:], crypto.SHA224, defaultIdentifier, false, false},
+		"good-SHA256":         {ctx, goodDigestSHA256[:], crypto.SHA256, defaultIdentifier, false, false},
+		"good-SHA384":         {ctx, goodDigestSHA384[:], crypto.SHA384, defaultIdentifier, false, false},
+		"good-SHA512":         {ctx, goodDigestSHA512[:], crypto.SHA512, defaultIdentifier, false, false},
+		"bad-digest":          {ctx, []byte("bad digest"), crypto.SHA256, defaultIdentifier, false, true},
+		"bad-wrong-hash":      {ctx, goodDigestSHA224[:], crypto.SHA256, defaultIdentifier, false, true},
+		"bad-identifier":      {ctx, goodDigestSHA224[:], crypto.SHA256, badIdentifier, false, true},
+		"bad-signer":          {ctx, goodDigestSHA224[:], crypto.SHA256, defaultIdentifier, true, true},
+		"bad-request-timeout": {timeoutCtx, goodDigestSHA512[:], crypto.SHA512, defaultIdentifier, false, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			signature, err := signer.SignBlob(ctx, tt.digest, tt.opts, tt.identifier)
+			signature, err := signer.SignBlob(tt.ctx, tt.digest, tt.opts, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -241,10 +241,6 @@ func TestSignX509Cert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate EC key: %v", err)
 	}
-	ec2key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-	if err != nil {
-		t.Fatalf("unable to generate EC key: %v", err)
-	}
 	certRSA := &x509.Certificate{
 		Subject:               subject,
 		SerialNumber:          big.NewInt(0),
@@ -271,19 +267,6 @@ func TestSignX509Cert(t *testing.T) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
-	certEC2 := &x509.Certificate{
-		Subject:               subject,
-		SerialNumber:          big.NewInt(0),
-		PublicKeyAlgorithm:    x509.ECDSA,
-		PublicKey:             &ec2key.PublicKey,
-		SignatureAlgorithm:    x509.ECDSAWithSHA384,
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour * 24),
-		DNSNames:              []string{subject.CommonName},
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-	}
 	cp := x509.NewCertPool()
 	caCertBytes, err := ioutil.ReadFile("testdata/rsa.cert.pem")
 	if err != nil {
@@ -295,29 +278,28 @@ func TestSignX509Cert(t *testing.T) {
 		t.Fatalf("unable to parse CA cert: %v", err)
 	}
 	cp.AddCert(caCert)
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+
 	testcases := map[string]struct {
-		ctx         context.Context
 		cert        *x509.Certificate
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"cert-rsa-good-signer":        {context.Background(), certRSA, defaultIdentifier, false, false},
-		"cert-ec-good-signer":         {context.Background(), certEC, defaultIdentifier, false, false},
-		"cert-bad-identifier":         {context.Background(), certRSA, badIdentifier, false, true},
-		"cert-bad-signer":             {context.Background(), certRSA, defaultIdentifier, true, true},
-		"cert-ec-good-signer-timeout": {timeoutCtx, certEC2, defaultIdentifier, false, true},
+		"cert-rsa-good-signer": {certRSA, defaultIdentifier, false, false},
+		"cert-ec-good-signer":  {certEC, defaultIdentifier, false, false},
+		"cert-bad-identifier":  {certRSA, badIdentifier, false, true},
+		"cert-bad-signer":      {certRSA, defaultIdentifier, true, true},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
+			var ctx context.Context
 			signer, err := initMockSigner(tt.isBadSigner)
 			if err != nil {
 				t.Fatalf("unable to init mock signer: %v", err)
 			}
-			data, err := signer.SignX509Cert(tt.ctx, tt.cert, tt.identifier)
+			data, err := signer.SignX509Cert(ctx, tt.cert, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -343,8 +325,6 @@ func TestSignX509Cert(t *testing.T) {
 			}
 		})
 	}
-	<-timeoutCtx.Done()
-	cancel()
 }
 
 func TestGetBlobSigningPublicKey(t *testing.T) {

--- a/pkcs11/signerpool_test.go
+++ b/pkcs11/signerpool_test.go
@@ -1,6 +1,7 @@
 package pkcs11
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
@@ -31,8 +32,8 @@ type MockSignerPool struct {
 	signer crypto.Signer
 }
 
-func (c MockSignerPool) get() signerWithSignAlgorithm {
-	return c
+func (c MockSignerPool) get(ctx context.Context) (signerWithSignAlgorithm, error) {
+	return c, nil
 }
 
 func (c MockSignerPool) put(instance signerWithSignAlgorithm) {

--- a/pkcs11/signerpool_test.go
+++ b/pkcs11/signerpool_test.go
@@ -33,7 +33,12 @@ type MockSignerPool struct {
 }
 
 func (c MockSignerPool) get(ctx context.Context) (signerWithSignAlgorithm, error) {
-	return c, nil
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("client timeout")
+	default:
+		return c, nil
+	}
 }
 
 func (c MockSignerPool) put(instance signerWithSignAlgorithm) {

--- a/server/server.go
+++ b/server/server.go
@@ -148,7 +148,7 @@ func Main(keyP crypki.KeyIDProcessor) {
 		log.Fatal(err)
 	}
 
-	signer, err := pkcs11.NewCertSign(cfg.ModulePath, cfg.Keys, keyUsages[config.X509CertEndpoint], hostname, ips)
+	signer, err := pkcs11.NewCertSign(ctx, cfg.ModulePath, cfg.Keys, keyUsages[config.X509CertEndpoint], hostname, ips)
 	if err != nil {
 		log.Fatalf("unable to initialize cert signer: %v", err)
 	}


### PR DESCRIPTION
This PR is to address high latency issue when there is a sudden spike in client requests. Due to the high latency issue, we see lot of client request timing out/canceled but the server still processes those requests which is a waste effort.
 
There are potentially 2 bottlenecks for increase in latency:
1. Currently we have limit on the poolsize of signers to 25 and each signer makes a request to HSM for signing the cert. During the spike in requests, we see the number of requests increasing exponentially and the server spending lot of time waiting for a signer from the pool. This causes the increase in latency as it is waiting ideally for a signer to make a request to HSM. 
2. HSM should always take a fixed amount of time to sign the request regardless of the load. (On an avg, if the key is RSA 4096, HSM can do approximately 66 req/sec whereas when it is EC 384, HSM can do around 280 req/sec.) If during the signing operation, the client cancels the request the server still completes the signing instead of freeing the resource.
 
This change is for signing x509 certificate to confirm the above theory. It addresses the latency issue mentioned in point 1 above, by having a timeout on the server side. If the request is not processed before server timeout expired, we will not enqueue the request for signing as the client may already have canceled the request and the response is not gonna be used. 


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
