### PR TITLE
Make timeouts configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,10 @@ const (
 	defaultShutdownOnSigningFailureTimerDurationSecond = 60
 	defaultShutdownOnSigningFailureTimerCount          = 10
 
+	defaultIdleTimeout  = 30
+	defaultReadTimeout  = 10
+	defaultWriteTimeout = 10
+
 	// X509CertEndpoint specifies the endpoint for signing X509 certificate.
 	X509CertEndpoint = "/sig/x509-cert"
 	// SSHUserCertEndpoint specifies the endpoint for signing SSH user certificate.
@@ -104,6 +108,11 @@ type Config struct {
 		TimerDurationSecond   uint
 		TimerCountLimit       uint
 	}
+
+	// timeouts used in initialization of http.Server (in seconds)
+	IdleTimeout  uint
+	ReadTimeout  uint
+	WriteTimeout uint
 }
 
 // Parse loads configuration values from input file and returns config object and CA cert.
@@ -211,5 +220,15 @@ func (c *Config) loadDefaults() {
 	}
 	if c.ShutdownOnInternalFailureCriteria.TimerCountLimit == 0 {
 		c.ShutdownOnInternalFailureCriteria.TimerCountLimit = defaultShutdownOnSigningFailureTimerCount
+	}
+
+	if c.IdleTimeout == 0 {
+		c.IdleTimeout = defaultIdleTimeout
+	}
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = defaultReadTimeout
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = defaultWriteTimeout
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,6 +41,9 @@ func TestParse(t *testing.T) {
 			TimerDurationSecond:   120,
 			TimerCountLimit:       20,
 		},
+		IdleTimeout:  30,
+		ReadTimeout:  10,
+		WriteTimeout: 10,
 	}
 	testcases := map[string]struct {
 		filePath    string

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -18,5 +18,8 @@
     "ConsecutiveCountLimit": 3,
     "TimerDurationSecond": 120,
     "TimerCountLimit": 20
-  }
+  },
+  "IdleTimeout": 30,
+  "ReadTimeout": 10,
+  "WriteTimeout": 10
 }


### PR DESCRIPTION
To fulfill a request, the HSM may take more than 10 seconds, which is the currently hard-coded value for `WriteTimeout`. Consequently, the client would receive the following error in such scenario.

```
code = Internal desc = stream terminated by RST_STREAM with error code: INTERNAL_ERROR
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
