### PR TITLE
make CA cert validity period configurable

### DIFF
--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -88,6 +88,7 @@ func main() {
 		Organization:           cc.Organization,
 		OrganizationalUnit:     cc.OrganizationalUnit,
 		CommonName:             cc.CommonName,
+		ValidityPeriod:         cc.ValidityPeriod,
 	}}, requireX509CACert, hostname, ips)
 	if err != nil {
 		log.Fatalf("unable to initialize cert signer: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,8 @@ type KeyConfig struct {
 	X509CACertLocation string
 	// Fields of the CA cert in subject line.
 	Country, State, Locality, Organization, OrganizationalUnit, CommonName string
+	// The validity time period of the CA cert in seconds.
+	ValidityPeriod uint64
 }
 
 // Config defines struct to store configuration fields for crypki.

--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,7 @@ type KeyConfig struct {
 	X509CACertLocation string
 	// Fields of the CA cert in subject line.
 	Country, State, Locality, Organization, OrganizationalUnit, CommonName string
-	// The validity time period of the CA cert in seconds.
+	// The validity time period of the CA cert, which is specified in seconds.
 	ValidityPeriod uint64
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,9 +19,9 @@ func TestParse(t *testing.T) {
 		TLSPort:           "4443",
 		SignersPerPool:    2,
 		Keys: []KeyConfig{
-			{"key1", 1, "/path/1", "foo", 2, 1, true, "/path/foo", "", "", "", "", "", "My CA"},
-			{"key2", 2, "/path/2", "bar", 2, 1, false, "", "", "", "", "", "", ""},
-			{"key3", 3, "/path/3", "baz", 2, 1, false, "/path/baz", "", "", "", "", "", ""},
+			{"key1", 1, "/path/1", "foo", 2, 1, true, "/path/foo", "", "", "", "", "", "My CA", 0},
+			{"key2", 2, "/path/2", "bar", 2, 1, false, "", "", "", "", "", "", "", 0},
+			{"key3", 3, "/path/3", "baz", 2, 1, false, "/path/baz", "", "", "", "", "", "", 0},
 		},
 		KeyUsages: []KeyUsage{
 			{"/sig/x509-cert", []string{"key1", "key3"}, 3600},

--- a/crypki.go
+++ b/crypki.go
@@ -58,7 +58,7 @@ type CAConfig struct {
 	OrganizationalUnit string `json:"OrganizationalUnit"`
 	CommonName         string `json:"CommonName"`
 
-	// The time period in seconds for the new signed CA cert.
+	// The validity time period of the CA cert, which is specified in seconds.
 	ValidityPeriod uint64 `json:"ValidityPeriod"`
 
 	// PKCS#11 device fields.

--- a/crypki.go
+++ b/crypki.go
@@ -68,3 +68,28 @@ type CAConfig struct {
 	UserPinPath      string `json:"UserPinPath"`
 	PKCS11ModulePath string `json:"PKCS11ModulePath"`
 }
+
+// LoadDefaults assigns default values to missing required configuration fields.
+func (c *CAConfig) LoadDefaults() {
+	if c.Country == "" {
+		c.CommonName = "ZZ" // Unknown or unspecified country
+	}
+	if c.State == "" {
+		c.State = "StateName"
+	}
+	if c.Locality == "" {
+		c.Locality = "CityName"
+	}
+	if c.Organization == "" {
+		c.Organization = "CompanyName"
+	}
+	if c.OrganizationalUnit == "" {
+		c.OrganizationalUnit = "OrganizationUnitName"
+	}
+	if c.CommonName == "" {
+		c.CommonName = "www.example.com"
+	}
+	if c.ValidityPeriod <= 0 {
+		c.ValidityPeriod = uint64(730 * 24 * 3600) // 2 years
+	}
+}

--- a/crypki.go
+++ b/crypki.go
@@ -58,6 +58,9 @@ type CAConfig struct {
 	OrganizationalUnit string `json:"OrganizationalUnit"`
 	CommonName         string `json:"CommonName"`
 
+	// The time period in seconds for the new signed CA cert.
+	ValidityPeriod uint64 `json:"ValidityPeriod"`
+
 	// PKCS#11 device fields.
 	Identifier       string `json:"Identifier"`
 	KeyLabel         string `json:"KeyLabel"`

--- a/crypki.go
+++ b/crypki.go
@@ -30,6 +30,16 @@ const (
 	UnknownPublicKeyAlgorithm PublicKeyAlgorithm = iota
 	RSA
 	ECDSA
+
+	// Default values for CAconfig.
+	defaultCounty = "ZZ" // Unknown or unspecified country
+	defaultState = "StateName"
+	defaultCity = "CityName"
+	defaultCompany = "CompanyName"
+	defaultOrganization = "OrganizationUnitName"
+	defaultCommonName = "www.example.com"
+	defaultValidityPeriod = uint64(730 * 24 * 3600) // 2 years
+
 )
 
 // CertSign interface contains methods related to signing certificates.
@@ -72,24 +82,24 @@ type CAConfig struct {
 // LoadDefaults assigns default values to missing required configuration fields.
 func (c *CAConfig) LoadDefaults() {
 	if c.Country == "" {
-		c.CommonName = "ZZ" // Unknown or unspecified country
+		c.Country = defaultCounty
 	}
 	if c.State == "" {
-		c.State = "StateName"
+		c.State = defaultState
 	}
 	if c.Locality == "" {
-		c.Locality = "CityName"
+		c.Locality = defaultCity
 	}
 	if c.Organization == "" {
-		c.Organization = "CompanyName"
+		c.Organization = defaultCompany
 	}
 	if c.OrganizationalUnit == "" {
-		c.OrganizationalUnit = "OrganizationUnitName"
+		c.OrganizationalUnit = defaultOrganization
 	}
 	if c.CommonName == "" {
-		c.CommonName = "www.example.com"
+		c.CommonName = defaultCommonName
 	}
 	if c.ValidityPeriod <= 0 {
-		c.ValidityPeriod = uint64(730 * 24 * 3600) // 2 years
+		c.ValidityPeriod = defaultValidityPeriod
 	}
 }

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -244,6 +244,7 @@ func getX509CACert(key config.KeyConfig, pool sPool, hostname string, ips []net.
 		Organization:       key.Organization,
 		OrganizationalUnit: key.OrganizationalUnit,
 		CommonName:         key.CommonName,
+		ValidityPeriod:     key.ValidityPeriod,
 	}, signer, hostname, ips, signer.signAlgorithm())
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate x509 CA certificate: %v", err)

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -237,7 +237,7 @@ func getX509CACert(key config.KeyConfig, pool sPool, hostname string, ips []net.
 	signer := pool.get()
 	defer pool.put(signer)
 
-	out, err := x509cert.GenCACert(&crypki.CAConfig{
+	caConfig := &crypki.CAConfig{
 		Country:            key.Country,
 		State:              key.State,
 		Locality:           key.Locality,
@@ -245,7 +245,10 @@ func getX509CACert(key config.KeyConfig, pool sPool, hostname string, ips []net.
 		OrganizationalUnit: key.OrganizationalUnit,
 		CommonName:         key.CommonName,
 		ValidityPeriod:     key.ValidityPeriod,
-	}, signer, hostname, ips, signer.signAlgorithm())
+	}
+	caConfig.LoadDefaults()
+
+	out, err := x509cert.GenCACert(caConfig, signer, hostname, ips, signer.signAlgorithm())
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate x509 CA certificate: %v", err)
 	}

--- a/x509cert/x509.go
+++ b/x509cert/x509.go
@@ -19,10 +19,6 @@ import (
 
 // GenCACert creates the CA certificate given signer.
 func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, ips []net.IP, pka crypki.PublicKeyAlgorithm) ([]byte, error) {
-	if config.ValidityPeriod == 0 {
-		config.ValidityPeriod = uint64(730 * 24 * 3600) // 2 years by default
-	}
-
 	// Backdate start time by one hour as the current system clock may be ahead of other running systems.
 	start := uint64(time.Now().Unix())
 	end := start + config.ValidityPeriod

--- a/x509cert/x509.go
+++ b/x509cert/x509.go
@@ -19,11 +19,13 @@ import (
 
 // GenCACert creates the CA certificate given signer.
 func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, ips []net.IP, pka crypki.PublicKeyAlgorithm) ([]byte, error) {
-	const validityPeriod = uint64(730 * 24 * 3600) // 2 years
+	if config.ValidityPeriod == 0 {
+		config.ValidityPeriod = uint64(730 * 24 * 3600) // default validity period is 2 years
+	}
 
 	// Backdate start time by one hour as the current system clock may be ahead of other running systems.
 	start := uint64(time.Now().Unix())
-	end := start + validityPeriod
+	end := start + config.ValidityPeriod
 	start -= 3600
 
 	subj := pkix.Name{

--- a/x509cert/x509.go
+++ b/x509cert/x509.go
@@ -20,7 +20,7 @@ import (
 // GenCACert creates the CA certificate given signer.
 func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, ips []net.IP, pka crypki.PublicKeyAlgorithm) ([]byte, error) {
 	if config.ValidityPeriod == 0 {
-		config.ValidityPeriod = uint64(730 * 24 * 3600) // default validity period is 2 years
+		config.ValidityPeriod = uint64(730 * 24 * 3600) // 2 years by default
 	}
 
 	// Backdate start time by one hour as the current system clock may be ahead of other running systems.


### PR DESCRIPTION
This PR enables a user to generate a CA cert with a configurable validity period.
The validity period would be 2 years if it is not specified in the configuration file.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
