### PR TITLE
Cancel server requests when client cancels - part 2 (SSH Cert)

### DIFF
--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -57,18 +57,45 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// create child context with timeout remaining from client request if present else until canceled
+	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
+	defer cancel() // Cancel ctx as soon as GetHostSSHCertificateSigningKey returns
+
 	if !s.KeyUsages[config.SSHHostCertEndpoint][keyMeta.Identifier] {
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("cannot use key %q for %q", keyMeta.Identifier, config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
-	if err != nil {
-		statusCode = http.StatusInternalServerError
-		return nil, status.Error(codes.Internal, "Internal server error")
+	type resp struct {
+		key []byte
+		err error
 	}
-	return &proto.SSHKey{Key: string(key)}, nil
+	respCh := make(chan resp)
+	go func() {
+		key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
+		respCh <- resp{key, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// client canceled the request. Cancel any pending server request and return
+		cancel()
+		statusCode = http.StatusBadRequest
+		err = fmt.Errorf("client canceled request for %q", config.SSHHostCertEndpoint)
+		return nil, status.Errorf(codes.Canceled, "%v", err)
+	case <-reqCtx.Done():
+		// server request timed out.
+		statusCode = http.StatusServiceUnavailable
+		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
+		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
+	case response := <-respCh:
+		if response.err != nil {
+			statusCode = http.StatusInternalServerError
+			return nil, status.Error(codes.Internal, "Internal server error")
+		}
+		return &proto.SSHKey{Key: string(response.key)}, nil
+	}
 }
 
 // PostHostSSHCertificate signs the SSH host certificate given request fields using the specified key.
@@ -95,6 +122,10 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
+	// create child context with timeout remaining from client request if present else until canceled
+	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
+	defer cancel() // Cancel ctx as soon as PostHostSSHCertificate returns
+
 	maxValidity := s.MaxValidity[config.SSHHostCertEndpoint]
 	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {
 		statusCode = http.StatusBadRequest
@@ -113,10 +144,33 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	data, err := s.SignSSHCert(ctx, cert, request.KeyMeta.Identifier)
-	if err != nil {
-		statusCode = http.StatusInternalServerError
-		return nil, status.Error(codes.Internal, "Internal server error")
+	type resp struct {
+		data []byte
+		err  error
 	}
-	return &proto.SSHKey{Key: string(data)}, nil
+	respCh := make(chan resp)
+	go func() {
+		data, err := s.SignSSHCert(ctx, cert, request.KeyMeta.Identifier)
+		respCh <- resp{data, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// client canceled the request. Cancel any pending server request and return
+		cancel()
+		statusCode = http.StatusBadRequest
+		err = fmt.Errorf("client canceled request for %q", config.SSHHostCertEndpoint)
+		return nil, status.Errorf(codes.Canceled, "%v", err)
+	case <-reqCtx.Done():
+		// server request timed out.
+		statusCode = http.StatusServiceUnavailable
+		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
+		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
+	case response := <-respCh:
+		if response.err != nil {
+			statusCode = http.StatusInternalServerError
+			return nil, status.Error(codes.Internal, "Internal server error")
+		}
+		return &proto.SSHKey{Key: string(response.data)}, nil
+	}
 }

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -57,7 +57,7 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create child context with timeout remaining from client request if present else until canceled
+	// create a context with server side timeout
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as GetHostSSHCertificateSigningKey returns
 
@@ -122,7 +122,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create child context with timeout remaining from client request if present else until canceled
+	// create a context with server side timeout
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as PostHostSSHCertificate returns
 

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -57,7 +57,7 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create child context with timeout remaining from client request if present else until canceled
+	// create a context with server side timeout
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as GetUserSSHCertificateSigningKey returns
 
@@ -122,7 +122,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create child context with timeout remaining from client request if present else until canceled
+	// create a context with server side timeout
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as PostUserSSHCertificate returns
 

--- a/api/sshuser_test.go
+++ b/api/sshuser_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/theparanoids/crypki/config"
 	"github.com/theparanoids/crypki/proto"
@@ -73,11 +74,16 @@ func TestGetUserSSHCertificateAvailableSigningKeys(t *testing.T) {
 
 func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	testcases := map[string]struct {
+		ctx       context.Context
 		KeyUsages map[string]map[string]bool
 		KeyMeta   *proto.KeyMeta
 		// if expectedSSHKey set to nil, we are expecting an error while testing
 		expectedSSHKey *proto.SSHKey
+		timeout        time.Duration
 	}{
 		"emptyKeyUsages": {
 			KeyMeta:        &proto.KeyMeta{Identifier: "randomid"},
@@ -111,24 +117,33 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid2"},
 			expectedSSHKey: nil,
 		},
+		"requestCancelled": {
+			ctx:            cancelCtx,
+			KeyUsages:      sshkeyUsage,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid"},
+			expectedSSHKey: nil,
+			timeout:        2 * timeout,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		if tt.ctx == nil {
+			tt.ctx = ctx
+		}
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
-			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: true}
+			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: true, timeout: tt.timeout}
 			ssBad := initMockSigningService(msspBad)
-			_, err := ssBad.GetUserSSHCertificateSigningKey(ctx, tt.KeyMeta)
+			_, err := ssBad.GetUserSSHCertificateSigningKey(tt.ctx, tt.KeyMeta)
 			if err == nil {
 				t.Fatalf("in test %v: bad signing service should return error but got nil", label)
 			}
 			// good certsign
-			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: false}
+			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, sendError: false, timeout: tt.timeout}
 			ssGood := initMockSigningService(msspGood)
-			key, err := ssGood.GetUserSSHCertificateSigningKey(ctx, tt.KeyMeta)
+			key, err := ssGood.GetUserSSHCertificateSigningKey(tt.ctx, tt.KeyMeta)
 			if err != nil && tt.expectedSSHKey != nil {
 				t.Fatalf("in test %v: not expecting error but got error %v", label, err)
 			}
@@ -141,6 +156,11 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 					return
 				}
 			}
+			if label == "requestCancelled" {
+				// this is to test the behavior when client cancels the request while
+				// server is still processing the request.
+				cancel()
+			}
 		})
 	}
 }
@@ -148,7 +168,13 @@ func TestGetUserSSHCertificateSigningKey(t *testing.T) {
 func TestPostUserSSHCertificate(t *testing.T) {
 	t.Parallel()
 	defaultMaxValidity := map[string]uint64{config.SSHUserCertEndpoint: 0}
+	ctx := context.Background()
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	timeoutCtx, timeCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer timeCancel()
 	testcases := map[string]struct {
+		ctx         context.Context
 		KeyUsages   map[string]map[string]bool
 		maxValidity map[string]uint64
 		validity    uint64
@@ -157,6 +183,7 @@ func TestPostUserSSHCertificate(t *testing.T) {
 		expectedSSHKey *proto.SSHKey
 		PubKey         string
 		KeyID          string
+		timeout        time.Duration
 	}{
 		"emptyKeyUsages": {
 			KeyMeta:        &proto.KeyMeta{Identifier: "randomid"},
@@ -288,27 +315,51 @@ func TestPostUserSSHCertificate(t *testing.T) {
 			PubKey:         testGoodRsaPubKey,
 			KeyID:          testGoodKeyID,
 		},
+		"requestCancelled": {
+			ctx:            cancelCtx,
+			KeyUsages:      sshkeyUsage,
+			maxValidity:    map[string]uint64{config.SSHUserCertEndpoint: 3600},
+			validity:       3600,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid1"},
+			expectedSSHKey: nil,
+			PubKey:         testGoodRsaPubKey,
+			KeyID:          testGoodKeyID,
+			timeout:        2 * timeout,
+		},
+		"requestTimeout": {
+			ctx:            timeoutCtx,
+			KeyUsages:      sshkeyUsage,
+			maxValidity:    map[string]uint64{config.SSHUserCertEndpoint: 3600},
+			validity:       3600,
+			KeyMeta:        &proto.KeyMeta{Identifier: "sshuserid1"},
+			expectedSSHKey: nil,
+			PubKey:         testGoodRsaPubKey,
+			KeyID:          testGoodKeyID,
+			timeout:        2 * timeout,
+		},
 	}
 	for label, tt := range testcases {
 		tt := tt
 		label := label
+		if tt.ctx == nil {
+			tt.ctx = ctx
+		}
 		t.Run(label, func(t *testing.T) {
 			t.Parallel()
-			var ctx context.Context
 			// bad certsign should return error anyways
-			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: true}
+			msspBad := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: true, timeout: tt.timeout}
 			ssBad := initMockSigningService(msspBad)
 			requestBad := &proto.SSHCertificateSigningRequest{KeyMeta: tt.KeyMeta, PublicKey: tt.PubKey, Validity: tt.validity, KeyId: tt.KeyID}
-			_, err := ssBad.PostUserSSHCertificate(ctx, requestBad)
+			_, err := ssBad.PostUserSSHCertificate(tt.ctx, requestBad)
 			if err == nil {
 				t.Fatalf("in test %v: bad signing service should return error but got nil", label)
 			}
 
 			// good certsign
-			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: false}
+			msspGood := mockSigningServiceParam{KeyUsages: tt.KeyUsages, MaxValidity: tt.maxValidity, sendError: false, timeout: tt.timeout}
 			ssGood := initMockSigningService(msspGood)
 			requestGood := &proto.SSHCertificateSigningRequest{KeyMeta: tt.KeyMeta, PublicKey: tt.PubKey, Validity: tt.validity, KeyId: tt.KeyID}
-			cert, err := ssGood.PostUserSSHCertificate(ctx, requestGood)
+			cert, err := ssGood.PostUserSSHCertificate(tt.ctx, requestGood)
 			if tt.expectedSSHKey == nil {
 				if err == nil {
 					t.Errorf("expected error for invalid test %v, got nil", label)
@@ -320,6 +371,11 @@ func TestPostUserSSHCertificate(t *testing.T) {
 				if !reflect.DeepEqual(cert, tt.expectedSSHKey) {
 					t.Errorf("output doesn't match for %v, got %+v\nwant %+v", label, cert, tt.expectedSSHKey)
 				}
+			}
+			if label == "requestCancelled" {
+				// this is to test the behavior when client cancels the request while
+				// server is still processing the request.
+				cancel()
 			}
 		})
 	}

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -89,7 +89,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create child context with timeout remaining from client request if present else until canceled
+	// create a context with server side timeout
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as PostX509Certificate returns
 

--- a/api/x509cert_test.go
+++ b/api/x509cert_test.go
@@ -273,17 +273,17 @@ func TestPostX509Certificate(t *testing.T) {
 		"requestTimeout": {
 			ctx:          timeoutCtx,
 			KeyUsages:    combineKeyUsage,
-			maxValidity:  map[string]uint64{config.X509CertEndpoint: 3600},
+			maxValidity:  defaultMaxValidity,
 			validity:     3600,
 			KeyMeta:      &proto.KeyMeta{Identifier: "x509id1"},
 			expectedCert: nil,
 			CSR:          testGoodcsrRsa,
 			timeout:      2 * timeout,
 		},
-		"requestCanceled": {
+		"requestCancelled": {
 			ctx:          cancelCtx,
 			KeyUsages:    combineKeyUsage,
-			maxValidity:  map[string]uint64{config.X509CertEndpoint: 3600},
+			maxValidity:  defaultMaxValidity,
 			validity:     3600,
 			KeyMeta:      &proto.KeyMeta{Identifier: "x509id1"},
 			expectedCert: nil,
@@ -324,7 +324,7 @@ func TestPostX509Certificate(t *testing.T) {
 					t.Errorf("output doesn't match for %v, got %+v\nwant %+v", label, cert, tt.expectedCert)
 				}
 			}
-			if label == "requestCanceled" {
+			if label == "requestCancelled" {
 				// this is to test the behavior when client cancels the request while
 				// server is still processing the request.
 				cancel()

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -102,7 +102,7 @@ func (s *signer) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIden
 	}()
 
 	if cert == nil {
-		return nil, errors.New("%s: cannot sign empty cert")
+		return nil, errors.New("signSSHCert: cannot sign empty cert")
 	}
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
@@ -110,7 +110,7 @@ func (s *signer) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIden
 	}
 	signer, err := pool.get(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("client request timed out, skip signing SSH cert")
 	}
 	defer pool.put(signer)
 
@@ -165,7 +165,7 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	}
 	signer, err := pool.get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("client request timed out, skip signing cert")
+		return nil, errors.New("client request timed out, skip signing X509 cert")
 	}
 	defer pool.put(signer)
 	cert.SignatureAlgorithm = getSignatureAlgorithm(signer.signAlgorithm())


### PR DESCRIPTION
The changes in this PR are targeted to address high latency when number of client requests increase exponentially. Due to high latency, we see a lot of requests being cancelled by the client but the server still processes causing the server spending a lot of time waiting for signer from the pool. 

As part of this PR we ensure that if the client has cancelled the request or timeout has occurred before server makes a request to HSM to sign a certificate the request will be cancelled. 

The change is made for request type: SSHUserCert & SSHHostCert for both signing SSH certificate and also getting SSH Certificate Key.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
