### PR TITLE
Add support for getting signed x509 cert

### DIFF
--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -56,9 +56,9 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create a context with server side timeout
+	// Create a context with server side timeout.
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
-	defer cancel() // Cancel ctx as soon as GetHostSSHCertificateSigningKey returns
+	defer cancel() // Cancel ctx as soon as GetX509CACertificate returns.
 
 	if !s.KeyUsages[config.X509CertEndpoint][keyMeta.Identifier] {
 		statusCode = http.StatusBadRequest
@@ -72,19 +72,17 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 	}
 	respCh := make(chan resp)
 	go func() {
-		key, err := s.GetX509CACert(ctx, keyMeta.Identifier)
-		respCh <- resp{key, err}
+		cert, err := s.GetX509CACert(ctx, keyMeta.Identifier)
+		respCh <- resp{cert, err}
 	}()
 
 	select {
 	case <-ctx.Done():
-		// client canceled the request. Cancel any pending server request and return
-		cancel()
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("client canceled request for %q", config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
-		// server request timed out.
+		// Handle the server timeout requests.
 		statusCode = http.StatusServiceUnavailable
 		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
@@ -116,7 +114,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create a context with server side timeout
+	// Create a context with server side timeout.
 	reqCtx, cancel := context.WithTimeout(ctx, config.DefaultPKCS11Timeout)
 	defer cancel() // Cancel ctx as soon as PostX509Certificate returns
 
@@ -140,24 +138,22 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	}
 
 	type resp struct {
-		data []byte
+		cert []byte
 		err  error
 	}
 	respCh := make(chan resp)
 	go func() {
-		data, err := s.SignX509Cert(reqCtx, req, request.KeyMeta.Identifier)
-		respCh <- resp{data, err}
+		cert, err := s.SignX509Cert(reqCtx, req, request.KeyMeta.Identifier)
+		respCh <- resp{cert, err}
 	}()
 
 	select {
 	case <-ctx.Done():
-		// client canceled the request. Cancel any pending server request and return
-		cancel()
 		statusCode = http.StatusBadRequest
 		err = fmt.Errorf("client canceled request for %q", config.X509CertEndpoint)
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
-		// server request timed out.
+		// Handle the server timeout requests.
 		statusCode = http.StatusServiceUnavailable
 		err = fmt.Errorf("request timed out for %q", config.X509CertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
@@ -166,6 +162,6 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 			statusCode = http.StatusInternalServerError
 			return nil, status.Error(codes.Internal, "Internal server error")
 		}
-		return &proto.X509Certificate{Cert: string(response.data)}, nil
+		return &proto.X509Certificate{Cert: string(response.cert)}, nil
 	}
 }


### PR DESCRIPTION
The changes in this PR are targeted to address the high latency when number of client requests increases exponentially due to retry. Due to the high latency, a lot of requests are cancelled by the client, but the server still tries to process them in the current setup, which causes the server to spend a lot of time waiting for a signer from the pool.

As part of this PR, we ensure that if the client has cancelled the request, or timeout has occurred before the server makes a request to HSM to get a certificate, the request will be cancelled.

A similar code change has been applied to `PostX509Certificate` in #56, and this PR caters for `GetX509CACertificate`.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
