### PR TITLE
Update return status code on request timeout

### DIFF
--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -86,7 +86,7 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// server request timed out.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:
@@ -163,7 +163,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// server request timed out.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -86,7 +86,7 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// server request timed out.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.SSHUserCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:
@@ -163,7 +163,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// server request timed out.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.SSHUserCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -83,7 +83,7 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// Handle the server timeout requests.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.SSHHostCertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:
@@ -154,7 +154,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	case <-reqCtx.Done():
 		// Handle the server timeout requests.
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusRequestTimeout
 		err = fmt.Errorf("request timed out for %q", config.X509CertEndpoint)
 		return nil, status.Errorf(codes.DeadlineExceeded, "%v", err)
 	case response := <-respCh:

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ const (
 	// BlobEndpoint specifies the endpoint for raw signing.
 	BlobEndpoint = "/sig/blob"
 	// DefaultPKCS11Timeout specifies the max time required by HSM to sign a cert.
-	DefaultPKCS11Timeout = 5 * time.Second
+	DefaultPKCS11Timeout = 15 * time.Second
 )
 
 var endpoints = map[string]bool{


### PR DESCRIPTION
In case the server times out waiting for signer or HSM to sign the request, the return status code should be StatusRequestTimeout(408) instead of StatusServiceUnavailable.
Also, increase the default timeout on the server side to 15 seconds instead of 5 seconds as the client has a timeout of 20 seconds and does not retry.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
