### PR TITLE
replace use of ioutil with io/os as part of 1.16 upgrade

### DIFF
--- a/api/blob_test.go
+++ b/api/blob_test.go
@@ -5,7 +5,7 @@ package api
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"log"
 	"reflect"
 	"sort"
@@ -16,7 +16,7 @@ import (
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func TestGetBlobAvailableSigningKeys(t *testing.T) {

--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -52,7 +51,7 @@ func main() {
 	if cfg == "" {
 		log.Fatal("no CA cert configuration file specified")
 	}
-	cfgData, err := ioutil.ReadFile(cfg)
+	cfgData, err := os.ReadFile(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkcs11/login.go
+++ b/pkcs11/login.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	p11 "github.com/miekg/pkcs11"
 
@@ -97,7 +97,7 @@ func getLoginSessions(p11ctx PKCS11Ctx, keys []config.KeyConfig, opts ...loginOp
 
 // getUserPinCode reads the pin code from the path and stores the pin code into the secure buffer.
 func getUserPinCode(path string) (*secureBuffer, error) {
-	pin, err := ioutil.ReadFile(path)
+	pin, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.New("Failed to open pin file: " + err.Error())
 	}

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -9,9 +9,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"time"
 
 	p11 "github.com/miekg/pkcs11"
@@ -240,7 +240,7 @@ func (s *signer) SignBlob(ctx context.Context, digest []byte, opts crypto.Signer
 // certificate will be generated based on the config, and wrote to X509CACertLocation.
 func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostname string, ips []net.IP) (*x509.Certificate, error) {
 	// Try parse certificate in the given location.
-	if certBytes, err := ioutil.ReadFile(key.X509CACertLocation); err == nil {
+	if certBytes, err := os.ReadFile(key.X509CACertLocation); err == nil {
 		block, _ := pem.Decode(certBytes)
 		if cert, err := x509.ParseCertificate(block.Bytes); err != nil {
 			log.Printf("unable to parse x509 certificate: %v", err)
@@ -278,7 +278,7 @@ func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostna
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate x509 CA certificate: %v", err)
 	}
-	if err := ioutil.WriteFile(key.X509CACertLocation, out, 0644); err != nil {
+	if err := os.WriteFile(key.X509CACertLocation, out, 0644); err != nil {
 		log.Printf("new CA cert generated, but unable to write to file %s: %v", key.X509CACertLocation, err)
 		log.Printf("cert generated: %q", string(out))
 	} else {

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -12,8 +12,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -47,11 +47,11 @@ func initMockSigner(isBad bool, keyType crypki.PublicKeyAlgorithm) (*signer, err
 	var bytes []byte
 	switch keyType {
 	case crypki.ECDSA:
-		bytes, err = ioutil.ReadFile("testdata/ec.cert.pem")
+		bytes, err = os.ReadFile("testdata/ec.cert.pem")
 	case crypki.RSA:
 		fallthrough
 	default:
-		bytes, err = ioutil.ReadFile("testdata/rsa.cert.pem")
+		bytes, err = os.ReadFile("testdata/rsa.cert.pem")
 	}
 	if err != nil {
 		return nil, err
@@ -273,7 +273,7 @@ func TestSignX509RSACert(t *testing.T) {
 		BasicConstraintsValid: true,
 	}
 	cp := x509.NewCertPool()
-	caCertBytes, err := ioutil.ReadFile("testdata/rsa.cert.pem")
+	caCertBytes, err := os.ReadFile("testdata/rsa.cert.pem")
 	if err != nil {
 		t.Fatalf("unable to read CA cert: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestSignX509ECCert(t *testing.T) {
 		BasicConstraintsValid: true,
 	}
 	cp := x509.NewCertPool()
-	caCertBytes, err := ioutil.ReadFile("testdata/ec.cert.pem")
+	caCertBytes, err := os.ReadFile("testdata/ec.cert.pem")
 	if err != nil {
 		t.Fatalf("unable to read CA cert: %v", err)
 	}
@@ -463,7 +463,7 @@ func TestSignBlob(t *testing.T) {
 	goodDigestSHA384 := sha512.Sum384(blob)
 	goodDigestSHA512 := sha512.Sum512(blob)
 
-	data, err := ioutil.ReadFile("testdata/rsa.key.pem")
+	data, err := os.ReadFile("testdata/rsa.key.pem")
 	if err != nil {
 		t.Fatalf("unable to read private key: %v", err)
 	}

--- a/pkcs11/signerpool_test.go
+++ b/pkcs11/signerpool_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -70,7 +70,7 @@ func newMockSignerPool(isBad bool, keyType crypki.PublicKeyAlgorithm) (sPool, er
 	}
 	switch keyType {
 	case crypki.ECDSA:
-		data, err := ioutil.ReadFile("testdata/ec.key.pem")
+		data, err := os.ReadFile("testdata/ec.key.pem")
 		if err != nil {
 			return nil, fmt.Errorf("unable to read private key: %v", err)
 		}
@@ -80,7 +80,7 @@ func newMockSignerPool(isBad bool, keyType crypki.PublicKeyAlgorithm) (sPool, er
 	case crypki.RSA:
 		fallthrough
 	default:
-		data, err := ioutil.ReadFile("testdata/rsa.key.pem")
+		data, err := os.ReadFile("testdata/rsa.key.pem")
 		if err != nil {
 			return nil, fmt.Errorf("unable to read private key: %v", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -64,7 +64,7 @@ func initHTTPServer(ctx context.Context, tlsConfig *tls.Config,
 		Addr: addr,
 		// to discard noisy messages like
 		// "http: TLS handshake error from 1.2.3.4:53651: EOF"
-		ErrorLog:     log.New(ioutil.Discard, "", 0),
+		ErrorLog:     log.New(io.Discard, "", 0),
 		Handler:      grpcHandlerFunc(ctx, grpcServer, mux),
 		IdleTimeout:  time.Duration(idleTimeout) * time.Second,
 		ReadTimeout:  time.Duration(readTimeout) * time.Second,
@@ -225,17 +225,17 @@ func Main(keyP crypki.KeyIDProcessor) {
 func tlsConfiguration(caCertPath string, certPath, keyPath string, clientAuthMode tls.ClientAuthType) (*tls.Config, error) {
 	cfg := &tls.Config{}
 	certPool := x509.NewCertPool()
-	caCert, err := ioutil.ReadFile(caCertPath)
+	caCert, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return nil, err
 	}
 	certPool.AppendCertsFromPEM(caCert)
 
-	keypem, err := ioutil.ReadFile(keyPath)
+	keypem, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, err
 	}
-	certpem, err := ioutil.ReadFile(certPath)
+	certpem, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/x509cert/encode_test.go
+++ b/x509cert/encode_test.go
@@ -5,7 +5,7 @@ package x509cert
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -57,7 +57,7 @@ func TestDecodeRequest(t *testing.T) {
 		tt := tt // capture range variable - see https://blog.golang.org/subtests
 		t.Run(k, func(t *testing.T) {
 			t.Parallel()
-			pemData, err := ioutil.ReadFile(tt.csrFile)
+			pemData, err := os.ReadFile(tt.csrFile)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR replaces use of ioutil.Discard with io.Discard & ioutil.ReadFile/ioutil.WriteFile with the corr. os package functions ReadFile & WriteFile. This change is done as part of the upgrade of go version to 1.16.
 
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
