### PR TITLE
Add detailed error comments when mismatch in signature algo

### DIFF
--- a/docker-softhsm/Dockerfile
+++ b/docker-softhsm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.2
+FROM golang:1.16.2
 ENV CRYPKI_DIR /go/src/github.com/theparanoids/crypki
 COPY . ${CRYPKI_DIR}
 WORKDIR ${CRYPKI_DIR}

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -169,7 +169,8 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	defer pool.put(signer)
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(cert, signer.signAlgorithm()); !val {
-		log.Printf("SignX509Cert: unsupported signature algo %d, supported algo %d", cert.SignatureAlgorithm, signer.signAlgorithm())
+		log.Printf("signX509cert: CN '%s' unsupported signature algo %d, supported signature algo %d",
+			s.x509CACerts[keyIdentifier].Subject.CommonName, cert.SignatureAlgorithm, signer.signAlgorithm())
 		// Not a valid signature algorithm. Overwrite it with what the configured keyType supports.
 		cert.SignatureAlgorithm = x509cert.GetSignatureAlgorithm(signer.signAlgorithm())
 	}
@@ -290,10 +291,5 @@ func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostna
 }
 
 func isValidCertRequest(cert *x509.Certificate, sa crypki.SignatureAlgorithm) bool {
-	x509ConfigSa := x509cert.GetSignatureAlgorithm(sa)
-
-	if cert.SignatureAlgorithm != x509ConfigSa {
-		return false
-	}
-	return true
+	return cert.SignatureAlgorithm == x509cert.GetSignatureAlgorithm(sa)
 }

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -169,8 +169,8 @@ func (s *signer) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyId
 	defer pool.put(signer)
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(cert, signer.signAlgorithm()); !val {
-		log.Printf("signX509cert: CN '%s' unsupported signature algo %d, supported signature algo %d",
-			s.x509CACerts[keyIdentifier].Subject.CommonName, cert.SignatureAlgorithm, signer.signAlgorithm())
+		log.Printf("signX509cert: cn=%q unsupported-sa=%q supported-sa=%d",
+			s.x509CACerts[keyIdentifier].Subject.CommonName, cert.SignatureAlgorithm.String(), signer.signAlgorithm())
 		// Not a valid signature algorithm. Overwrite it with what the configured keyType supports.
 		cert.SignatureAlgorithm = x509cert.GetSignatureAlgorithm(signer.signAlgorithm())
 	}


### PR DESCRIPTION
This PR consists of changes for adding more info in comments when there is a mismatch in signature algo. It also simplifies the check in isValidCert method.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
