### PR TITLE
Add gen.sh to install tool binaries automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 cmd/crypki/crypki
 docker-softhsm/log
 docker-softhsm/tls-crt
+tools_bin/

--- a/Contributing.md
+++ b/Contributing.md
@@ -24,3 +24,7 @@ Before you submit any code, we need you to agree to our [Contributor License Agr
 Please follow [best practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices) for creating git commits.
 
 When your code is ready to be submitted, you can [submit a pull request](https://help.github.com/articles/creating-a-pull-request/) to begin the code review process.
+
+#### Generate Go Code
+
+If your work requires re-generating the code (e.g. mock), please run `./gen.sh` at the project root.

--- a/gen.sh
+++ b/gen.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This script does 2 things:
+# 1. Install all the tool binaries required to generate code.
+# 2. Run "go generate" to generate code.
+set -euo pipefail
+
+main() {
+  # Since different projects may have different versions of tool binaries,
+  # we first install tool binaries of the version specified in the go.mod of this project,
+  # and the binaries will be placed under the tools_bin directory of this project and git-ignored.
+  GOBIN=$(pwd)/tools_bin
+  export GOBIN
+  go install github.com/golang/mock/mockgen
+  go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+  go install google.golang.org/protobuf/cmd/protoc-gen-go
+
+  # Make sure that we are using the tool binaries which are just built to generate code.
+  export PATH=$GOBIN:$PATH
+  go generate ./...
+}
+
+main


### PR DESCRIPTION
PR adds `gen.sh` to install tool binaries automatically without side-effects. One can still use `go generate` without `gen.sh` if he/she prefers to install the tool binaries manually somehow.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
