### PR TITLE
remove extra hsm call when getting x509 ca cert

### DIFF
--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -134,16 +134,6 @@ func (s *signer) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIden
 }
 
 func (s *signer) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
-	pool, ok := s.sPool[keyIdentifier]
-	if !ok {
-		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
-	}
-	signer, err := pool.get(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer pool.put(signer)
-
 	cert, ok := s.x509CACerts[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unable to find CA cert for key identifier %q", keyIdentifier)

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -243,18 +243,14 @@ func TestSignSSHCert(t *testing.T) {
 func TestGetX509CACert(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 	testcases := map[string]struct {
-		ctx         context.Context
 		identifier  string
 		isBadSigner bool
 		expectError bool
 	}{
-		"good-signer":         {ctx, defaultIdentifier, false, false},
-		"bad-identifier":      {ctx, badIdentifier, false, true},
-		"bad-signer":          {ctx, defaultIdentifier, true, false},
-		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
+		"good-signer":    {defaultIdentifier, false, false},
+		"bad-identifier": {badIdentifier, false, true},
+		"bad-signer":     {defaultIdentifier, true, false},
 	}
 	for label, tt := range testcases {
 		label, tt := label, tt
@@ -265,7 +261,7 @@ func TestGetX509CACert(t *testing.T) {
 				t.Fatalf("unable to create CA keys and certificate: %v", err)
 			}
 			signer := initMockSigner(crypki.RSA, caPriv, caCert, tt.isBadSigner)
-			_, err = signer.GetX509CACert(tt.ctx, tt.identifier)
+			_, err = signer.GetX509CACert(ctx, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}


### PR DESCRIPTION
When fetching x509 ca cert, we fetch the cert from filesystem and we do not need to make an extra call to HSM. This PR fixes that issue.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
