### PR TITLE
remove locality support from x509 & gen cacert

### DIFF
--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -91,7 +91,6 @@ func main() {
 			CreateCACertIfNotExist: true,
 			Country:                cc.Country,
 			State:                  cc.State,
-			Locality:               cc.Locality,
 			Organization:           cc.Organization,
 			OrganizationalUnit:     cc.OrganizationalUnit,
 			CommonName:             cc.CommonName,

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ type KeyConfig struct {
 	// X509CACertLocation is the path to the x509 CA certificate.
 	X509CACertLocation string
 	// Fields of the CA cert in subject line.
-	Country, State, Locality, Organization, OrganizationalUnit, CommonName string
+	Country, State, Organization, OrganizationalUnit, CommonName string
 	// The validity time period of the CA cert, which is specified in seconds.
 	ValidityPeriod uint64
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,9 +19,9 @@ func TestParse(t *testing.T) {
 		TLSPort:           "4443",
 		SignersPerPool:    2,
 		Keys: []KeyConfig{
-			{"key1", 1, "", "/path/1", "foo", 2, 2, 3, []string{}, []string{}, true, "/path/foo", "", "", "", "", "", "My CA", 0},
-			{"key2", 2, "", "/path/2", "bar", 2, 1, 1, []string{"http://test.ocsp.com:8888"}, []string{"http://test.crl.com:8889"}, false, "", "", "", "", "", "", "", 0},
-			{"key3", 0, "foo", "/path/3", "baz", 2, 1, 1, []string{"http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"}, []string{"http://test1.crl.com:8889", "http://test2.crl.com:8889"}, false, "/path/baz", "", "", "", "", "", "", 0},
+			{"key1", 1, "", "/path/1", "foo", 2, 2, 3, []string{}, []string{}, true, "/path/foo", "", "", "", "", "My CA", 0},
+			{"key2", 2, "", "/path/2", "bar", 2, 1, 1, []string{"http://test.ocsp.com:8888"}, []string{"http://test.crl.com:8889"}, false, "", "", "", "", "", "", 0},
+			{"key3", 0, "foo", "/path/3", "baz", 2, 1, 1, []string{"http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"}, []string{"http://test1.crl.com:8889", "http://test2.crl.com:8889"}, false, "/path/baz", "", "", "", "", "", 0},
 		},
 		KeyUsages: []KeyUsage{
 			{"/sig/x509-cert", []string{"key1", "key3"}, 3600},

--- a/crypki.go
+++ b/crypki.go
@@ -47,7 +47,7 @@ const (
 
 const (
 	// Default values for CAconfig.
-	defaultCounty         = "ZZ" // Unknown or unspecified country
+	defaultCountry        = "ZZ" // Unknown or unspecified country
 	defaultCompany        = "CompanyName"
 	defaultOrganization   = "OrganizationUnitName"
 	defaultCommonName     = "www.example.com"
@@ -76,7 +76,6 @@ type CAConfig struct {
 	// Subject fields.
 	Country            string `json:"Country"`
 	State              string `json:"State"`
-	Locality           string `json:"Locality"`
 	Organization       string `json:"Organization"`
 	OrganizationalUnit string `json:"OrganizationalUnit"`
 	CommonName         string `json:"CommonName"`
@@ -97,7 +96,7 @@ type CAConfig struct {
 // LoadDefaults assigns default values to missing required configuration fields.
 func (c *CAConfig) LoadDefaults() {
 	if c.Country == "" {
-		c.Country = defaultCounty
+		c.Country = defaultCountry
 	}
 	if c.Organization == "" {
 		c.Organization = defaultCompany

--- a/docker-softhsm/crypki.conf.sample
+++ b/docker-softhsm/crypki.conf.sample
@@ -39,7 +39,6 @@
             "KeyLabel": "host_x509",
             "KeyType": 2,
             "SignatureAlgo": 3,
-            "Locality": "Example",
             "Organization": "Example! Inc.",
             "OrganizationalUnit": "Example",
             "SlotNumber": SLOTNUM_HOST_X509,

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -299,7 +299,6 @@ func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostna
 	caConfig := &crypki.CAConfig{
 		Country:            key.Country,
 		State:              key.State,
-		Locality:           key.Locality,
 		Organization:       key.Organization,
 		OrganizationalUnit: key.OrganizationalUnit,
 		CommonName:         key.CommonName,

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -69,7 +69,6 @@ func createCAKeysAndCert(keyType crypki.PublicKeyAlgorithm) (priv crypto.Signer,
 		Subject: pkix.Name{
 			Country:      []string{"US"},
 			Organization: []string{"Oath Inc."},
-			Locality:     []string{"Sunnyvale"},
 			CommonName:   "testca.cameo.ouroath.com",
 		},
 		SerialNumber:          big.NewInt(1),
@@ -373,7 +372,6 @@ func TestSignX509ECCert(t *testing.T) {
 		Country:            []string{"US"},
 		Organization:       []string{"Foo"},
 		OrganizationalUnit: []string{"FooUnit"},
-		Locality:           []string{"Bar"},
 		Province:           []string{"Baz"},
 		CommonName:         "foo.bar.com",
 	}

--- a/x509cert/x509.go
+++ b/x509cert/x509.go
@@ -23,12 +23,9 @@ func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, i
 	start := uint64(time.Now().Unix())
 	end := start + config.ValidityPeriod
 	start -= 3600
-	var country, locality, province, org, orgUnit []string
+	var country, province, org, orgUnit []string
 	if config.Country != "" {
 		country = []string{config.Country}
-	}
-	if config.Locality != "" {
-		locality = []string{config.Locality}
 	}
 	if config.State != "" {
 		province = []string{config.State}
@@ -43,7 +40,6 @@ func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, i
 	subj := pkix.Name{
 		CommonName:         config.CommonName,
 		Country:            country,
-		Locality:           locality,
 		Province:           province,
 		Organization:       org,
 		OrganizationalUnit: orgUnit,

--- a/x509cert/x509_test.go
+++ b/x509cert/x509_test.go
@@ -94,7 +94,6 @@ func TestGenCACert(t *testing.T) {
 		"all-fields": {
 			cfg: &crypki.CAConfig{
 				Country:            "US",
-				Locality:           "Sunnyvale",
 				State:              "CA",
 				Organization:       "Foo Org",
 				OrganizationalUnit: "Foo Org Unit",
@@ -107,7 +106,6 @@ func TestGenCACert(t *testing.T) {
 			wantSubj: pkix.Name{
 				CommonName:         "foo.example.com",
 				Country:            []string{"US"},
-				Locality:           []string{"Sunnyvale"},
 				Province:           []string{"CA"},
 				Organization:       []string{"Foo Org"},
 				OrganizationalUnit: []string{"Foo Org Unit"},
@@ -116,7 +114,6 @@ func TestGenCACert(t *testing.T) {
 		"no-ST": {
 			cfg: &crypki.CAConfig{
 				Country:            "US",
-				Locality:           "Sunnyvale",
 				Organization:       "Foo Org",
 				OrganizationalUnit: "Foo Org Unit",
 				CommonName:         "foo.example.com",
@@ -128,7 +125,6 @@ func TestGenCACert(t *testing.T) {
 			wantSubj: pkix.Name{
 				CommonName:         "foo.example.com",
 				Country:            []string{"US"},
-				Locality:           []string{"Sunnyvale"},
 				Organization:       []string{"Foo Org"},
 				OrganizationalUnit: []string{"Foo Org Unit"},
 			},
@@ -156,7 +152,6 @@ func TestGenCACert(t *testing.T) {
 		"no-Org": {
 			cfg: &crypki.CAConfig{
 				Country:            "US",
-				Locality:           "Sunnyvale",
 				State:              "CA",
 				OrganizationalUnit: "Foo Org Unit",
 				CommonName:         "foo.example.com",
@@ -168,7 +163,6 @@ func TestGenCACert(t *testing.T) {
 			wantSubj: pkix.Name{
 				CommonName:         "foo.example.com",
 				Country:            []string{"US"},
-				Locality:           []string{"Sunnyvale"},
 				Province:           []string{"CA"},
 				OrganizationalUnit: []string{"Foo Org Unit"},
 			},


### PR DESCRIPTION
This PR removes the locality field from x509 & gen cacert as it is no longer required.
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
