### PR TITLE
Support priority based scheduling for requests.

### DIFF
--- a/api/sign.go
+++ b/api/sign.go
@@ -17,6 +17,7 @@ type SigningService struct {
 	crypki.KeyIDProcessor
 	KeyUsages   map[string]map[string]bool
 	MaxValidity map[string]uint64
+	RequestChan map[string]chan interface{}
 	proto.UnimplementedSigningServer
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ type KeyUsage struct {
 	// Maximum allowed validity period in seconds for a certificate signed by
 	// this endpoint. If not specified default is infinity.
 	MaxValidity uint64
+	// PriorityBasedScheduling indicates whether to prioritize requests based on the priority/urgency of the request
+	// being received. If not specified, all requests are treated with equal priority.
+	PriorityBasedScheduling bool
 }
 
 // KeyConfig contains information about a particular signing key inside HSM.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,10 +24,10 @@ func TestParse(t *testing.T) {
 			{"key3", 0, "foo", "/path/3", "baz", 2, 1, 1, []string{"http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"}, []string{"http://test1.crl.com:8889", "http://test2.crl.com:8889"}, false, "/path/baz", "", "", "", "", "", "", 0},
 		},
 		KeyUsages: []KeyUsage{
-			{"/sig/x509-cert", []string{"key1", "key3"}, 3600},
-			{"/sig/ssh-host-cert", []string{"key1", "key2"}, 36000},
-			{"/sig/ssh-user-cert", []string{"key3"}, 36000},
-			{"/sig/blob", []string{"key1"}, 36000},
+			{"/sig/x509-cert", []string{"key1", "key3"}, 3600, true},
+			{"/sig/ssh-host-cert", []string{"key1", "key2"}, 36000, false},
+			{"/sig/ssh-user-cert", []string{"key3"}, 36000, false},
+			{"/sig/blob", []string{"key1"}, 36000, false},
 		},
 		ShutdownOnInternalFailure: true,
 		ShutdownOnInternalFailureCriteria: struct {

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -7,10 +7,10 @@
     {"Identifier": "key3", "KeyLabel": "baz", "KeyType": 1, "SignatureAlgo": 1, "SlotNumber": 0, "TokenLabel": "foo", "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz", "OCSPServers": ["http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"], "CRLDistributionPoints": ["http://test1.crl.com:8889", "http://test2.crl.com:8889"]}
   ],
   "KeyUsages": [
-    {"Endpoint": "/sig/x509-cert", "Identifiers": ["key1", "key3"], "MaxValidity": 3600},
-    {"Endpoint": "/sig/ssh-host-cert", "Identifiers": ["key1", "key2"], "MaxValidity": 36000},
-    {"Endpoint": "/sig/ssh-user-cert", "Identifiers": ["key3"], "MaxValidity": 36000},
-    {"Endpoint": "/sig/blob", "Identifiers": ["key1"], "MaxValidity": 36000}
+    {"Endpoint": "/sig/x509-cert", "Identifiers": ["key1", "key3"], "MaxValidity": 3600, "PriorityBasedScheduling": true},
+    {"Endpoint": "/sig/ssh-host-cert", "Identifiers": ["key1", "key2"], "MaxValidity": 36000, "PriorityBasedScheduling": false},
+    {"Endpoint": "/sig/ssh-user-cert", "Identifiers": ["key3"], "MaxValidity": 36000, "PriorityBasedScheduling": false},
+    {"Endpoint": "/sig/blob", "Identifiers": ["key1"], "MaxValidity": 36000, "PriorityBasedScheduling": false}
   ],
   "ShutdownOnInternalFailure": true,
   "ShutdownOnInternalFailureCriteria": {

--- a/pkcs11/mock_signerpool.go
+++ b/pkcs11/mock_signerpool.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pkcs11
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"io"
+
+	"github.com/theparanoids/crypki"
+)
+
+type badSigner struct{}
+
+func (b *badSigner) Public() crypto.PublicKey {
+	return []byte("bad byte")
+}
+
+func (b *badSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return nil, errors.New("bad signer")
+}
+
+type MockSignerPool struct {
+	signer  crypto.Signer
+	keyType crypki.PublicKeyAlgorithm
+}
+
+func (c MockSignerPool) Get(ctx context.Context) (SignerWithSignAlgorithm, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("client timeout")
+	default:
+		return c, nil
+	}
+}
+
+func (c MockSignerPool) Put(instance SignerWithSignAlgorithm) {
+
+}
+
+func (c MockSignerPool) PublicKeyAlgorithm() crypki.PublicKeyAlgorithm {
+	return c.keyType
+}
+
+func (c MockSignerPool) SignAlgorithm() crypki.SignatureAlgorithm {
+	if c.keyType == crypki.ECDSA {
+		return crypki.ECDSAWithSHA256
+	}
+	return crypki.SHA256WithRSA
+}
+
+func (c MockSignerPool) Public() crypto.PublicKey {
+	return c.signer.Public()
+}
+
+func (c MockSignerPool) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	return c.signer.Sign(rand, digest, opts)
+}
+
+func NewMockSignerPool(isBad bool, keyType crypki.PublicKeyAlgorithm, priv crypto.Signer) SPool {
+	if isBad {
+		return MockSignerPool{&badSigner{}, keyType}
+	}
+	return MockSignerPool{priv, keyType}
+}

--- a/pkcs11/p11signer.go
+++ b/pkcs11/p11signer.go
@@ -78,12 +78,12 @@ func (s *p11Signer) Public() crypto.PublicKey {
 	}
 }
 
-// publicAlgorithm returns the public key algorithm of signer.
-func (s *p11Signer) publicKeyAlgorithm() crypki.PublicKeyAlgorithm {
+// PublicKeyAlgorithm returns the public key algorithm of signer.
+func (s *p11Signer) PublicKeyAlgorithm() crypki.PublicKeyAlgorithm {
 	return s.keyType
 }
 
-// signAlgorithm returns the signature algorithm of signer.
-func (s *p11Signer) signAlgorithm() crypki.SignatureAlgorithm {
+// SignAlgorithm returns the signature algorithm of signer.
+func (s *p11Signer) SignAlgorithm() crypki.SignatureAlgorithm {
 	return s.signatureAlgo
 }

--- a/pkcs11/signerpool_test.go
+++ b/pkcs11/signerpool_test.go
@@ -15,10 +15,7 @@
 package pkcs11
 
 import (
-	"context"
-	"crypto"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -26,60 +23,6 @@ import (
 	"github.com/theparanoids/crypki"
 	"github.com/theparanoids/crypki/pkcs11/mock_pkcs11"
 )
-
-type badSigner struct{}
-
-func (b *badSigner) Public() crypto.PublicKey {
-	return []byte("bad byte")
-}
-
-func (b *badSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return nil, errors.New("bad signer")
-}
-
-type MockSignerPool struct {
-	signer  crypto.Signer
-	keyType crypki.PublicKeyAlgorithm
-}
-
-func (c MockSignerPool) get(ctx context.Context) (signerWithSignAlgorithm, error) {
-	select {
-	case <-ctx.Done():
-		return nil, errors.New("client timeout")
-	default:
-		return c, nil
-	}
-}
-
-func (c MockSignerPool) put(instance signerWithSignAlgorithm) {
-
-}
-
-func (c MockSignerPool) publicKeyAlgorithm() crypki.PublicKeyAlgorithm {
-	return c.keyType
-}
-
-func (c MockSignerPool) signAlgorithm() crypki.SignatureAlgorithm {
-	if c.keyType == crypki.ECDSA {
-		return crypki.ECDSAWithSHA256
-	}
-	return crypki.SHA256WithRSA
-}
-
-func (c MockSignerPool) Public() crypto.PublicKey {
-	return c.signer.Public()
-}
-
-func (c MockSignerPool) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-	return c.signer.Sign(rand, digest, opts)
-}
-
-func newMockSignerPool(isBad bool, keyType crypki.PublicKeyAlgorithm, priv crypto.Signer) sPool {
-	if isBad {
-		return MockSignerPool{&badSigner{}, keyType}
-	}
-	return MockSignerPool{priv, keyType}
-}
 
 func TestNewSignerPool(t *testing.T) {
 	t.Parallel()

--- a/server/priority/counter.go
+++ b/server/priority/counter.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import "sync/atomic"
+
+type Counter int32
+
+func (c *Counter) Get() int32 {
+	return atomic.LoadInt32((*int32)(c))
+}
+func (c *Counter) Inc() int32 {
+	return atomic.AddInt32((*int32)(c), 1)
+}
+func (c *Counter) Reset() int32 {
+	return atomic.SwapInt32((*int32)(c), 0)
+}

--- a/server/priority/counter_test.go
+++ b/server/priority/counter_test.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestCounter(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		count     Counter
+		operation func(count Counter) int32
+		want      int32
+	}{
+		"get empty counter": {
+			operation: func(count Counter) int32 {
+				return count.Get()
+			},
+			want: 0,
+		},
+		"inc counter": {
+			operation: func(count Counter) int32 {
+				count.Inc()
+				count.Inc()
+				return count.Get()
+			},
+			want: 2,
+		},
+		"inc & reset counter": {
+			operation: func(count Counter) int32 {
+				count.Inc()
+				count.Inc()
+				count.Reset()
+				count.Inc()
+				return count.Get()
+			},
+			want: 1,
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.operation(tt.count)
+			if got != tt.want {
+				t.Errorf("%s: expected %d, got %d", name, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCounterMultipleGoRoutines(t *testing.T) {
+	t.Parallel()
+	var totalCount Counter
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		totalCount.Inc()
+		totalCount.Reset()
+		totalCount.Inc()
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		for i := 1; i < 100; i++ {
+			totalCount.Inc()
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+	fmt.Printf("count: %d\n", totalCount.Get())
+	if totalCount.Get() == 0 {
+		t.Errorf("count not incremented correctly, got 0")
+	}
+}

--- a/server/priority/priority.go
+++ b/server/priority/priority.go
@@ -1,0 +1,114 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/theparanoids/crypki/pkcs11"
+	"github.com/theparanoids/crypki/proto"
+)
+
+const (
+	QueueSize = 100
+)
+
+// CollectRequest is responsible for receiving work requests from the client & dispatches the request to dispatcher
+// & waits for another request.
+func CollectRequest(ctx context.Context, requestChan <-chan interface{}, dispatcherChan chan<- interface{}, endpoint string) {
+	log.Printf("start collecting requests for endpoint %q", endpoint)
+	for {
+		select {
+		case req := <-requestChan:
+			dispatcherChan <- req
+		case <-ctx.Done():
+			log.Printf("server context is closed, stop collector. %v", ctx.Err())
+			close(dispatcherChan)
+			return
+		}
+	}
+}
+
+// DispatchRequest waits on any new request being enqueued by CollectRequest. It parses the incoming request and assigns it to
+// correct priority queue. It also starts workers based on SessionPoolSize. Workers would notify the dispatcher if they are
+// idle & dispatcher assigns work based on priority. It also does work stealing. If the feature is turned off, we treat each
+// request as high priority and proceed acc.
+func DispatchRequest(ctx context.Context, dispatcherChan <-chan interface{}, nworkers int, priorityBasedScheduling bool, endpoint string) {
+	pmap := map[proto.Priority]chan interface{}{}
+	for pri := range proto.Priority_name {
+		pmap[proto.Priority(pri)] = make(chan interface{}, QueueSize)
+	}
+
+	// create new workers
+	workerQueue := make(chan Worker, nworkers)
+	workers := createWorkers(ctx, workerQueue, nworkers)
+
+	// Get statistics every 5 minutes for total requests processed per priority for each endpoint.
+	go dumpStats(ctx, workers, endpoint, 5*time.Minute)
+
+	go func() {
+		for {
+			select {
+			case evt, ok := <-dispatcherChan:
+				if !ok {
+					dispatcherChan = nil
+					return
+				}
+				req, ok := evt.(pkcs11.Request)
+				if !ok {
+					log.Printf("invalid request type %T received, skip processing it", evt)
+					return
+				}
+				if !priorityBasedScheduling {
+					pmap[proto.Priority_High] <- req
+				} else {
+					pmap[req.Priority] <- req
+				}
+			case w := <-workerQueue:
+				// worker is idle, assign some work to the worker
+				go w.assignWork(ctx, pmap)
+			case <-ctx.Done():
+				log.Printf("server context is closed, close dispatcher. %v", ctx.Err())
+				return
+			}
+		}
+	}()
+}
+
+func dumpStats(ctx context.Context, workers []*Worker, endpoint string, tickerTime time.Duration) {
+	ticker := time.NewTicker(tickerTime)
+	for {
+		select {
+		case <-ticker.C:
+			priorityCount := map[int32]int32{}
+			for _, worker := range workers {
+				for pri := range proto.Priority_name {
+					priorityCount[pri] += worker.totalProcessed[priorityToValMap[(proto.Priority(pri))]].Get()
+					worker.totalProcessed[priorityToValMap[(proto.Priority(pri))]].Reset()
+				}
+			}
+			msg := fmt.Sprintf("total requests processed for %q: ", endpoint)
+			for pri, val := range proto.Priority_name {
+				msg += fmt.Sprintf("%s=%d ", val, priorityCount[pri])
+			}
+			log.Println(msg)
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}

--- a/server/priority/priority_test.go
+++ b/server/priority/priority_test.go
@@ -1,0 +1,229 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import (
+	"context"
+	mrand "math/rand"
+	"testing"
+	"time"
+
+	"github.com/theparanoids/crypki"
+	"github.com/theparanoids/crypki/pkcs11"
+	"github.com/theparanoids/crypki/proto"
+)
+
+func TestCollectRequest(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	tests := map[string]struct {
+		ctx      context.Context
+		req      func() pkcs11.Request
+		wantResp bool
+	}{
+		"happy path": {
+			ctx: ctx,
+			req: func() pkcs11.Request {
+				caPriv, err := createCAKey(crypki.RSA)
+				if err != nil {
+					t.Fatalf("error getting CA Priv key: %v", err)
+				}
+				req := pkcs11.Request{
+					Pool:          pkcs11.NewMockSignerPool(false, crypki.RSA, caPriv),
+					Priority:      proto.Priority_High,
+					InsertTime:    time.Now(),
+					RemainingTime: 10 * time.Second,
+					RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+				}
+				return req
+			},
+			wantResp: true,
+		},
+		"client context deadline exceeded": {
+			ctx: timeoutCtx,
+			req: func() pkcs11.Request {
+				caPriv, err := createCAKey(crypki.ECDSA)
+				if err != nil {
+					t.Fatalf("error getting CA Priv key: %v", err)
+				}
+				req := pkcs11.Request{
+					Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+					Priority:      proto.Priority_High,
+					InsertTime:    time.Now(),
+					RemainingTime: 10 * time.Second,
+					RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+				}
+				cancel()
+				return req
+			},
+			wantResp: false,
+		},
+	}
+
+	requestChan := make(chan interface{})
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			dispatcherChan := make(chan interface{})
+			go CollectRequest(tt.ctx, requestChan, dispatcherChan, "dummy")
+			if tt.ctx == timeoutCtx {
+				cancel()
+			} else {
+				requestChan <- tt.req()
+			}
+			select {
+			case _, ok := <-dispatcherChan:
+				if tt.wantResp && !ok || !tt.wantResp && ok {
+					t.Fatalf("%s: expected resp %v got %v", name, tt.wantResp, ok)
+				}
+			case <-tt.ctx.Done():
+			}
+		})
+	}
+}
+
+func TestDispatchRequest(t *testing.T) {
+	t.Parallel()
+	requestChan := make(chan interface{})
+	dispatcherChan := make(chan interface{})
+	caPriv, err := createCAKey(crypki.ECDSA)
+	if err != nil {
+		t.Fatalf("error getting CA Priv key: %v", err)
+	}
+	go CollectRequest(context.Background(), requestChan, dispatcherChan, "dummy")
+	priorities := []proto.Priority{proto.Priority_Unspecified_priority, proto.Priority_High, proto.Priority_Medium, proto.Priority_Low}
+
+	tests := map[string]struct {
+		desc           string
+		nworkers       int
+		featureEnabled bool
+		requestFn      func()
+	}{
+		"2 workers multiple requests feature enabled": {
+			desc:           "ensure workers are not idle & they always have some work in the queue",
+			nworkers:       2,
+			featureEnabled: true,
+			requestFn: func() {
+				for i := 1; i <= 10; i++ {
+					priority := priorities[mrand.Intn(len(priorities))]
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      priority,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+		"multiple workers 5 requests feature enabled": {
+			desc:           "multiple workers will be idle as very few requests",
+			nworkers:       10,
+			featureEnabled: true,
+			requestFn: func() {
+				for i := 1; i <= 5; i++ {
+					priority := priorities[mrand.Intn(len(priorities))]
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      priority,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+		"multiple workers multiple request feature disabled": {
+			desc:           "feature disabled so all requests are treated as high priority",
+			nworkers:       10,
+			featureEnabled: false,
+			requestFn: func() {
+				for i := 1; i <= 30; i++ {
+					priority := priorities[mrand.Intn(len(priorities))]
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      priority,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+		"few workers with medium priority requests feature enabled": {
+			desc:           "all requests are medium priority so other workers do work stealing",
+			nworkers:       5,
+			featureEnabled: true,
+			requestFn: func() {
+				for i := 1; i <= 20; i++ {
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      proto.Priority_Medium,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+		"multiple workers with low priority requests feature enabled": {
+			desc:           "all requests are low priority so other workers do work stealing",
+			nworkers:       5,
+			featureEnabled: true,
+			requestFn: func() {
+				for i := 1; i <= 20; i++ {
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      proto.Priority_Low,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+		"multiple workers with unspecified priority requests feature disabled": {
+			desc:           "all requests are unspecified priority so other workers do work stealing",
+			nworkers:       5,
+			featureEnabled: false,
+			requestFn: func() {
+				for i := 1; i <= 20; i++ {
+					req := pkcs11.Request{
+						Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+						Priority:      proto.Priority_Unspecified_priority,
+						InsertTime:    time.Now(),
+						RemainingTime: 10 * time.Second,
+						RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+					}
+					requestChan <- req
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Run(name, func(t *testing.T) {
+			go DispatchRequest(ctx, dispatcherChan, tt.nworkers, tt.featureEnabled, "dummy")
+			tt.requestFn()
+		})
+		cancel()
+	}
+}

--- a/server/priority/worker.go
+++ b/server/priority/worker.go
@@ -1,0 +1,141 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/theparanoids/crypki/pkcs11"
+	"github.com/theparanoids/crypki/proto"
+)
+
+const waitTime = 50 * time.Millisecond
+
+var priorityToValMap = map[proto.Priority]int32{
+	proto.Priority_Unspecified_priority: 0,
+	proto.Priority_High:                 1,
+	proto.Priority_Medium:               2,
+	proto.Priority_Low:                  3,
+}
+
+// Worker holds individual worker info used to create and send work by dispatcher.
+type Worker struct {
+	id             int              // id is a unique id for the worker
+	totalProcessed []Counter        // totalProcessed indicates the total request processed per priority by this worker.
+	priority       proto.Priority   // priority indicates the priority of the request the worker is handling.
+	workChan       chan interface{} // workChan is a channel which has a request enqueue for the worker to work on.
+	workerQueue    chan Worker      // workerQueue is a channel to notify the dispatcher worker is idle.
+	quitChan       chan bool        // quitChan is a channel to cancel the worker
+}
+
+// newWorker creates & returns a new worker object. Its argument is the id, the worker type & a channel
+// that the worker can add itself to when it is idle.
+func newWorker(workerId int, workerPriority proto.Priority, workerQueue chan Worker) *Worker {
+	totalProcessed := make([]Counter, len(proto.Priority_name))
+	return &Worker{
+		id:             workerId,
+		priority:       workerPriority,
+		workChan:       make(chan interface{}),
+		workerQueue:    workerQueue,
+		quitChan:       make(chan bool),
+		totalProcessed: totalProcessed,
+	}
+}
+
+// createWorkers creates different workers with different priorities. We currently split the num. of workers
+// such that there are 4x high priority workers, 2x medium priority workers & 1x low priority workers. This method ensures
+// we do not starve lower priority requests. As an argument it takes the total number of workers we should create.
+func createWorkers(ctx context.Context, workerQueue chan Worker, nWorkers int) []*Worker {
+	// Since there are total 7 parts (4, 2, 1) we divide the parts in given ratio & assign to each priority.
+	var workers []*Worker
+	nHighPriWorkers := (4 * nWorkers) / 7
+	nMedPriWorkers := (2 * nWorkers) / 7
+	for i := 0; i < nWorkers; i++ {
+		var worker *Worker
+		if i < nHighPriWorkers {
+			worker = newWorker(i, proto.Priority_High, workerQueue)
+		} else if i <= (nHighPriWorkers + nMedPriWorkers) {
+			worker = newWorker(i, proto.Priority_Medium, workerQueue)
+		} else {
+			worker = newWorker(i, proto.Priority_Low, workerQueue)
+		}
+		worker.start(ctx)
+		workers = append(workers, worker)
+	}
+	return workers
+}
+
+// assignWork assigns the request to the worker based on the priority of the worker. If no request of the worker priority
+// exists, worker will start stealing work from the higher priority queue. If no work for higher priority Q exists, it will
+// sleep for waitTime (currently 50 milliseconds) and retry.
+func (w *Worker) assignWork(ctx context.Context, pmap map[proto.Priority]chan interface{}) {
+	for {
+		select {
+		case request := <-pmap[w.priority]:
+			w.workChan <- request
+			return
+		case <-ctx.Done():
+			log.Printf("request cancelled, stop assigning work")
+			return
+		default:
+			// steal work from work queue
+			// Did not find any work to steal, sleep for 50 milliseconds before retrying.
+			time.Sleep(waitTime)
+		}
+	}
+}
+
+// start method performs the work for the worker. It will fetch the signer from the pool & assign it back to the caller
+// using the respChan.
+func (w *Worker) start(ctx context.Context) {
+	go func() {
+		for {
+			// Add ourself into worker queue
+			w.workerQueue <- *w
+			select {
+			case evt := <-w.workChan:
+				work, ok := evt.(pkcs11.Request)
+				if !ok {
+					log.Printf("invalid work received. skip processing it")
+					continue
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), work.RemainingTime)
+				signer, err := work.Pool.Get(ctx)
+				if err != nil {
+					log.Printf("error fetching signer %v", err)
+					work.RespChan <- nil
+					cancel()
+					continue
+				}
+				w.totalProcessed[priorityToValMap[work.Priority]].Inc()
+				work.RespChan <- signer
+				cancel()
+			case <-ctx.Done():
+				log.Printf("worker %d stopped, request cancelled", w.id)
+				return
+			case <-w.quitChan:
+				// We have been asked to stop.
+				log.Printf("worker %d stopping", w.id)
+				return
+			}
+		}
+	}()
+}
+
+func (w *Worker) stop() {
+	log.Printf("stop worker %d", w.id)
+	w.quitChan <- true
+}

--- a/server/priority/worker_test.go
+++ b/server/priority/worker_test.go
@@ -1,0 +1,210 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package priority
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	mrand "math/rand"
+	"testing"
+	"time"
+
+	"github.com/theparanoids/crypki"
+	"github.com/theparanoids/crypki/pkcs11"
+	"github.com/theparanoids/crypki/proto"
+)
+
+const (
+	timeout = 50 * time.Millisecond
+)
+
+func TestCreateWorkers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	tests := map[string]struct {
+		ctx     context.Context
+		nWorker int
+		wQueue  func(nWorker int) chan Worker
+	}{
+		"10 workers": {
+			nWorker: 10,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+		},
+		"1 worker": {
+			nWorker: 1,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+		},
+		"context cancelled": {
+			ctx:     timeoutCtx,
+			nWorker: 10,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			if tt.ctx != timeoutCtx {
+				tt.ctx = ctx
+			}
+			workers := createWorkers(tt.ctx, tt.wQueue(tt.nWorker), tt.nWorker)
+			if tt.ctx == ctx {
+				for _, w := range workers {
+					w.stop()
+				}
+			}
+		})
+	}
+}
+
+// createCAKeys generates key pairs for unit tests CA based on key type.
+func createCAKey(keyType crypki.PublicKeyAlgorithm) (priv crypto.Signer, err error) {
+	switch keyType {
+	case crypki.ECDSA:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case crypki.RSA:
+		fallthrough
+	default:
+		return rsa.GenerateKey(rand.Reader, 2048)
+	}
+}
+
+func TestCreateWorkers_PerformWork(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	priorities := []proto.Priority{proto.Priority_High, proto.Priority_Medium, proto.Priority_Low}
+	tests := map[string]struct {
+		nWorkers    int
+		wQueue      func(nWorker int) chan Worker
+		request     func(priority proto.Priority) pkcs11.Request
+		stopWorkers func(workers []*Worker)
+		wantErr     bool
+	}{
+		"2 workers RSA key": {
+			nWorkers: 2,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+			request: func(priority proto.Priority) pkcs11.Request {
+				caPriv, err := createCAKey(crypki.RSA)
+				if err != nil {
+					t.Fatalf("unable to create CA keys and certificate: %v", err)
+				}
+				req := pkcs11.Request{
+					Pool:          pkcs11.NewMockSignerPool(false, crypki.RSA, caPriv),
+					Priority:      priority,
+					InsertTime:    time.Now(),
+					RemainingTime: 10 * time.Second,
+					RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+				}
+				return req
+			},
+			stopWorkers: func(workers []*Worker) {
+				for _, w := range workers {
+					w.stop()
+				}
+			},
+			wantErr: false,
+		},
+		"10 workers EC key": {
+			nWorkers: 10,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+			request: func(priority proto.Priority) pkcs11.Request {
+				caPriv, err := createCAKey(crypki.ECDSA)
+				if err != nil {
+					t.Fatalf("unable to create CA keys and certificate: %v", err)
+				}
+				req := pkcs11.Request{
+					Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+					Priority:      priority,
+					InsertTime:    time.Now(),
+					RemainingTime: 10 * time.Second,
+					RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+				}
+				return req
+			},
+			stopWorkers: func(workers []*Worker) {
+				for _, w := range workers {
+					w.stop()
+				}
+			},
+			wantErr: false,
+		},
+		"client timed out": {
+			nWorkers: 10,
+			wQueue: func(nWorker int) chan Worker {
+				return make(chan Worker, nWorker)
+			},
+			request: func(priority proto.Priority) pkcs11.Request {
+				caPriv, err := createCAKey(crypki.ECDSA)
+				if err != nil {
+					t.Fatalf("unable to create CA keys and certificate: %v", err)
+				}
+				req := pkcs11.Request{
+					Pool:          pkcs11.NewMockSignerPool(false, crypki.ECDSA, caPriv),
+					Priority:      priority,
+					InsertTime:    time.Now(),
+					RemainingTime: 0,
+					RespChan:      make(chan pkcs11.SignerWithSignAlgorithm),
+				}
+				return req
+			},
+			stopWorkers: func(workers []*Worker) {
+				for _, w := range workers {
+					w.stop()
+				}
+			},
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			workers := createWorkers(ctx, tt.wQueue(tt.nWorkers), tt.nWorkers)
+			// send work to workers
+			for _, w := range workers {
+				priority := priorities[mrand.Intn(len(priorities))]
+				request := tt.request(priority)
+				w.workChan <- request
+				signer := <-request.RespChan
+				if signer == nil && !tt.wantErr {
+					t.Fatalf("%s: received no response from worker", name)
+				} else if signer != nil && tt.wantErr {
+					t.Fatalf("%s: received response from worker when error expected", name)
+				}
+				// worker should be idle & waiting for more work
+				select {
+				case <-w.workerQueue:
+				case <-ctx.Done():
+				}
+			}
+			tt.stopWorkers(workers)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -33,9 +33,13 @@ import (
 	"github.com/theparanoids/crypki/pkcs11"
 	"github.com/theparanoids/crypki/proto"
 	"github.com/theparanoids/crypki/server/interceptor"
+	"github.com/theparanoids/crypki/server/priority"
 )
 
-const defaultLogFile = "/var/log/crypki/server.log"
+const (
+	defaultLogFile = "/var/log/crypki/server.log"
+	poolSize       = 10
+)
 
 // grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
 // connections or otherHandler otherwise. More: https://grpc.io/blog/coreos
@@ -129,6 +133,8 @@ func Main(keyP crypki.KeyIDProcessor) {
 
 	keyUsages := make(map[string]map[string]bool)
 	maxValidity := make(map[string]uint64)
+	requestChan := make(map[string]chan interface{})
+	dispatcherChan := make(map[string]chan interface{})
 
 	for _, usage := range cfg.KeyUsages {
 		keyUsages[usage.Endpoint] = make(map[string]bool)
@@ -136,6 +142,10 @@ func Main(keyP crypki.KeyIDProcessor) {
 			keyUsages[usage.Endpoint][id] = true
 		}
 		maxValidity[usage.Endpoint] = usage.MaxValidity
+		requestChan[usage.Endpoint] = make(chan interface{})
+		dispatcherChan[usage.Endpoint] = make(chan interface{}, priority.QueueSize)
+		go priority.CollectRequest(ctx, requestChan[usage.Endpoint], dispatcherChan[usage.Endpoint], usage.Endpoint)
+		go priority.DispatchRequest(ctx, dispatcherChan[usage.Endpoint], poolSize, usage.PriorityBasedScheduling, usage.Endpoint)
 	}
 
 	hostname, err := os.Hostname()
@@ -202,7 +212,7 @@ func Main(keyP crypki.KeyIDProcessor) {
 		grpc.ChainUnaryInterceptor(interceptors...),
 	}...)
 
-	ss := &api.SigningService{CertSign: signer, KeyUsages: keyUsages, MaxValidity: maxValidity, KeyIDProcessor: keyP}
+	ss := &api.SigningService{CertSign: signer, KeyUsages: keyUsages, MaxValidity: maxValidity, KeyIDProcessor: keyP, RequestChan: requestChan}
 	if err := proto.RegisterSigningHandlerServer(ctx, gwmux, ss); err != nil {
 		log.Fatalf("crypki: failed to register signing service handler, err: %v", err)
 	}


### PR DESCRIPTION
This PR adds support for signing certs based on the priority sent as part of the request. It creates the necessary go functions and routines for handling request with different priorities. It also creates workers to actually work on the request and send the response back.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
