### PR TITLE
add client support for priority scheduling feature

### DIFF
--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/theparanoids/crypki"
 	"github.com/theparanoids/crypki/config"
+	"github.com/theparanoids/crypki/proto"
+	"github.com/theparanoids/crypki/server/scheduler"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -98,7 +100,7 @@ func (mbcs *mockBadCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certific
 func (mbcs *mockBadCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
@@ -120,7 +122,7 @@ func (mgcs *mockGoodCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certifi
 func (mgcs *mockGoodCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 ca cert"), nil
 }
-func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return []byte("good x509 cert"), nil
 }
 func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -143,7 +143,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	}
 	respCh := make(chan resp)
 	go func() {
-		cert, err := s.SignX509Cert(reqCtx, req, request.KeyMeta.Identifier)
+		cert, err := s.SignX509Cert(reqCtx, s.RequestChan[config.X509CertEndpoint], req, request.KeyMeta.Identifier, request.Priority)
 		respCh <- resp{cert, err}
 	}()
 

--- a/crypki.go
+++ b/crypki.go
@@ -8,6 +8,9 @@ import (
 	"crypto"
 	"crypto/x509"
 
+	"github.com/theparanoids/crypki/proto"
+	"github.com/theparanoids/crypki/server/scheduler"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -64,7 +67,7 @@ type CertSign interface {
 	// GetX509CACert returns the X509 CA cert of the specified key.
 	GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignX509Cert returns an x509 cert signed by the specified key.
-	SignX509Cert(ctx context.Context, cert *x509.Certificate, keyIdentifier string) ([]byte, error)
+	SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error)
 	// GetBlobSigningPublicKey returns the public signing key of the specified key that signs the user's data.
 	GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignBlob returns a signature signed by the specified key.

--- a/server/scheduler/workerpool.go
+++ b/server/scheduler/workerpool.go
@@ -49,7 +49,7 @@ func (p *Pool) initialize() {
 			worker := newWorker(i, pri)
 			p.workers = append(p.workers, worker)
 		}
-		j = size
+		j += size
 		p.requestQueue[pri] = make(chan *Request, size)
 	}
 }
@@ -59,7 +59,7 @@ func (p *Pool) start(ctx context.Context) {
 	for _, worker := range p.workers {
 		worker.start(ctx, p.requestQueue)
 	}
-	log.Println("all workers started")
+	log.Printf("all workers started for %q", p.Name)
 }
 
 // stop stops all the workers from processing any new requests
@@ -67,7 +67,7 @@ func (p *Pool) stop(ctx context.Context) {
 	for _, worker := range p.workers {
 		worker.stop()
 	}
-	log.Println("all workers stopped")
+	log.Printf("all workers stopped for %q", p.Name)
 }
 
 // enqueueRequest enqueues any new incoming request to appropriate request queue based on the priority.

--- a/server/server.go
+++ b/server/server.go
@@ -144,6 +144,7 @@ func Main(keyP crypki.KeyIDProcessor) {
 			idEpMap[id] = priorityDispatchInfo{usage.Endpoint, usage.PrioritySchedulingEnabled, false}
 			keyUsages[usage.Endpoint][id] = true
 		}
+		requestChan[usage.Endpoint] = make(chan scheduler.Request)
 		maxValidity[usage.Endpoint] = usage.MaxValidity
 	}
 
@@ -153,7 +154,6 @@ func Main(keyP crypki.KeyIDProcessor) {
 		v := idEpMap[key.Identifier]
 		if !v.collectRequest {
 			v.collectRequest = true
-			requestChan[v.endpoint] = make(chan scheduler.Request)
 			p := &scheduler.Pool{Name: v.endpoint, PoolSize: key.SessionPoolSize, FeatureEnabled: v.priSchedFeature}
 			go scheduler.CollectRequest(ctx, requestChan[v.endpoint], p)
 		}


### PR DESCRIPTION
This PR comprises of changes needed for any request to be scheduled based on the priority it is sent with. The request will enqueue itself to the request channel and wait for workers to process the request & get a signer from the pool and return to the original request to perform the operation.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
