### PR TITLE
Add priority scheduling feature for ssh & blob key signing

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -108,7 +108,7 @@ func (s *SigningService) PostSignBlob(ctx context.Context, request *proto.BlobSi
 	}
 
 	signerOpts := getSignerOpts(request.HashAlgorithm.String())
-	signature, err := s.SignBlob(ctx, digest, signerOpts, request.KeyMeta.Identifier)
+	signature, err := s.SignBlob(ctx, s.RequestChan[config.BlobEndpoint], digest, signerOpts, request.KeyMeta.Identifier, request.Priority)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -94,7 +94,7 @@ type mockBadCertSign struct {
 func (mbcs *mockBadCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
@@ -106,7 +106,7 @@ func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, reqChan chan sche
 func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 
@@ -116,7 +116,7 @@ type mockGoodCertSign struct {
 func (mgcs *mockGoodCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good ssh signing key"), nil
 }
-func (mgcs *mockGoodCertSign) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return []byte("good ssh cert"), nil
 }
 func (mgcs *mockGoodCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
@@ -128,7 +128,7 @@ func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, reqChan chan sch
 func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
 	return []byte("good blob signing key"), nil
 }
-func (mgcs *mockGoodCertSign) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return []byte("good blob signature"), nil
 }
 

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -150,7 +150,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 	}
 	respCh := make(chan resp)
 	go func() {
-		data, err := s.SignSSHCert(ctx, cert, request.KeyMeta.Identifier)
+		data, err := s.SignSSHCert(ctx, s.RequestChan[config.SSHHostCertEndpoint], cert, request.KeyMeta.Identifier, request.Priority)
 		respCh <- resp{data, err}
 	}()
 

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -150,7 +150,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 	}
 	respCh := make(chan resp)
 	go func() {
-		data, err := s.SignSSHCert(reqCtx, cert, request.KeyMeta.Identifier)
+		data, err := s.SignSSHCert(reqCtx, s.RequestChan[config.SSHUserCertEndpoint], cert, request.KeyMeta.Identifier, request.Priority)
 		respCh <- resp{data, err}
 	}()
 

--- a/crypki.go
+++ b/crypki.go
@@ -63,7 +63,7 @@ type CertSign interface {
 	// GetSSHCertSigningKey returns the SSH signing key of the specified key.
 	GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignSSHCert returns an SSH cert signed by the specified key.
-	SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error)
+	SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error)
 	// GetX509CACert returns the X509 CA cert of the specified key.
 	GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignX509Cert returns an x509 cert signed by the specified key.
@@ -71,7 +71,7 @@ type CertSign interface {
 	// GetBlobSigningPublicKey returns the public signing key of the specified key that signs the user's data.
 	GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error)
 	// SignBlob returns a signature signed by the specified key.
-	SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error)
+	SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error)
 }
 
 // CAConfig represents the configuration params for generating the CA certificate.

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -149,7 +149,7 @@ func (s *signer) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string)
 	return ssh.MarshalAuthorizedKey(sshSigner.PublicKey()), nil
 }
 
-func (s *signer) SignSSHCert(ctx context.Context, cert *ssh.Certificate, keyIdentifier string) ([]byte, error) {
+func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	const methodName = "SignSSHCert"
 	start := time.Now()
 	var ht, st int64
@@ -290,7 +290,7 @@ func (s *signer) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier stri
 	return pem.EncodeToMemory(b), nil
 }
 
-func (s *signer) SignBlob(ctx context.Context, digest []byte, opts crypto.SignerOpts, keyIdentifier string) ([]byte, error) {
+func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	const methodName = "SignBlob"
 	start := time.Now()
 	var ht int64

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -44,7 +44,6 @@ import (
 type Request struct {
 	pool          sPool                        // pool is a signer pool per identifier from which to fetch the signer
 	identifier    string                       // identifier indicates the endpoint for which we are fetching the signer in order to sign it
-	requestTime   time.Time                    // requestTime is the time when the request arrived
 	remainingTime time.Duration                // remainingTime indicates the time remaining before either the client cancels or the request times out.
 	respChan      chan signerWithSignAlgorithm // respChan is the channel where the worker sends the signer once it gets it from the pool
 }
@@ -77,6 +76,42 @@ func getRemainingRequestTime(ctx context.Context, keyIdentifier string) (time.Du
 		}
 	}
 	return remTime, nil
+}
+
+func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority) (signer signerWithSignAlgorithm, err error) {
+	remTime, err := getRemainingRequestTime(ctx, keyIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	respChan := make(chan signerWithSignAlgorithm)
+	req := &Request{
+		pool:          pool,
+		identifier:    keyIdentifier,
+		remainingTime: remTime,
+		respChan:      respChan,
+	}
+	if priority == proto.Priority_Unspecified_priority {
+		// If priority is unspecified, treat the request as high priority.
+		priority = proto.Priority_High
+	}
+	select {
+	case requestChan <- scheduler.Request{Priority: priority, DoWorker: &Work{work: req}}:
+	case <-ctx.Done():
+		// channel closed
+		// this should ideally not happen but in order to avoid a blocking call we add this check in place
+		return nil, errors.New("request channel is closed, cannot fetch signer")
+	}
+	var ok bool
+	select {
+	case signer, ok = <-respChan:
+		if signer == nil || !ok {
+			return nil, errors.New("client request timed out, skip signing X509 cert")
+		}
+	case <-ctx.Done():
+		// In order to ensure we don't keep on blocking on the response, we add this check.
+		return nil, ctx.Err()
+	}
+	return signer, nil
 }
 
 // NewCertSign initializes a CertSign object that interacts with PKCS11 compliant device.
@@ -152,10 +187,10 @@ func (s *signer) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string)
 func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	const methodName = "SignSSHCert"
 	start := time.Now()
-	var ht, st int64
+	var ht, pt int64
 	defer func() {
 		tt := time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds()
-		log.Printf("m=%s: ht=%d, tt=%d, st=%d", methodName, ht, tt, st)
+		log.Printf("m=%s: ht=%d, tt=%d, pt=%d", methodName, ht, tt, pt)
 	}()
 
 	if cert == nil {
@@ -165,13 +200,13 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	sStart := time.Now()
-	signer, err := pool.get(ctx)
+	pStart := time.Now()
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
-		st = time.Since(sStart).Nanoseconds() / time.Microsecond.Nanoseconds()
-		return nil, errors.New("client request timed out, skip signing SSH cert")
+		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
+		return nil, err
 	}
-	st = time.Since(sStart).Nanoseconds() / time.Microsecond.Nanoseconds()
+	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
 
 	sshSigner, err := ssh.NewSignerFromSigner(signer)
@@ -200,7 +235,7 @@ func (s *signer) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byt
 	return certBytes, nil
 }
 
-func (s *signer) SignX509Cert(ctx context.Context, requestChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
+func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	const methodName = "SignX509Cert"
 	start := time.Now()
 	var ht, pt int64
@@ -214,42 +249,14 @@ func (s *signer) SignX509Cert(ctx context.Context, requestChan chan scheduler.Re
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	remTime, err := getRemainingRequestTime(ctx, keyIdentifier)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
+		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
-	}
-	respChan := make(chan signerWithSignAlgorithm)
-	req := &Request{
-		pool:          pool,
-		identifier:    keyIdentifier,
-		requestTime:   start,
-		remainingTime: remTime,
-		respChan:      respChan,
-	}
-	if priority == proto.Priority_Unspecified_priority {
-		// If priority is unspecified, treat the request as high priority.
-		priority = proto.Priority_High
-	}
-	select {
-	case requestChan <- scheduler.Request{Priority: priority, DoWorker: &Work{work: req}}:
-	case <-ctx.Done():
-		// channel closed
-		// this should ideally not happen but in order to avoid a blocking call we add this check in place
-		return nil, errors.New("request channel is closed, cannot fetch signer")
-	}
-	var signer signerWithSignAlgorithm
-	select {
-	case signer, ok = <-respChan:
-		if signer == nil || !ok {
-			pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
-			return nil, errors.New("client request timed out, skip signing X509 cert")
-		}
-	case <-ctx.Done():
-		// In order to ensure we don't keep on blocking on the response, we add this check.
-		return nil, ctx.Err()
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
+
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(cert, signer.signAlgorithm()); !val {
 		log.Printf("signX509cert: cn=%q unsupported-sa=%q supported-sa=%d",
@@ -293,10 +300,10 @@ func (s *signer) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier stri
 func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	const methodName = "SignBlob"
 	start := time.Now()
-	var ht int64
+	var ht, pt int64
 	defer func() {
 		tt := time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds()
-		log.Printf("m=%s: ht=%d, tt=%d", methodName, ht, tt)
+		log.Printf("m=%s: ht=%d, tt=%d, pt=%d", methodName, ht, tt, pt)
 	}()
 
 	if digest == nil {
@@ -306,10 +313,13 @@ func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, d
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
-	signer, err := pool.get(ctx)
+	pStart := time.Now()
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
+		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
 	}
+	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
 
 	// measure time taken by hsm


### PR DESCRIPTION
This PR is a follow-up of #120 & #121. It supports priority based scheduling feature for signing SSH & Blob keys.
 
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
