### PR TITLE
Explicitly use signature algorithm for SSH certs

### DIFF
--- a/crypki.go
+++ b/crypki.go
@@ -46,6 +46,8 @@ const (
 	SHA256WithRSA
 	ECDSAWithSHA256
 	ECDSAWithSHA384
+	SHA512WithRSA
+	SHAWithRSA // for backward compatibility
 )
 
 const (

--- a/pkcs11/algosigner.go
+++ b/pkcs11/algosigner.go
@@ -54,19 +54,10 @@ func getSignatureAlgorithm(publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki
 			}
 		}
 	case crypki.ECDSA:
-		{
-			// For ECDSA public algorithm, signature algo does not exist. We pass in
-			// empty algorithm & the upstream code will ensure the right algorithm is chosen
-			// for signing the cert.
-			switch signAlgo {
-			case crypki.ECDSAWithSHA256, crypki.ECDSAWithSHA384:
-				return
-			case crypki.SHAWithRSA, crypki.SHA256WithRSA, crypki.SHA512WithRSA:
-				err = errors.New("public key algo & signature algo mismatch, unable to get AlgorithmSigner")
-			default:
-				return
-			}
-		}
+		// For ECDSA public algorithm, signature algo does not exist. We pass in
+		// empty algorithm & the crypto library will ensure the right algorithm is chosen
+		// for signing the cert.
+		return
 	default:
 		err = errors.New("public key algorithm not supported")
 	}

--- a/pkcs11/algosigner.go
+++ b/pkcs11/algosigner.go
@@ -64,6 +64,7 @@ func getSignatureAlgorithm(publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki
 			case crypki.SHAWithRSA, crypki.SHA256WithRSA, crypki.SHA512WithRSA:
 				err = errors.New("public key algo & signature algo mismatch, unable to get AlgorithmSigner")
 			default:
+				return
 			}
 		}
 	default:

--- a/pkcs11/algosigner.go
+++ b/pkcs11/algosigner.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pkcs11
+
+import (
+	"crypto"
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/theparanoids/crypki"
+)
+
+type sshAlgorithmSigner struct {
+	algorithm string
+	signer    ssh.AlgorithmSigner
+}
+
+func (s *sshAlgorithmSigner) PublicKey() ssh.PublicKey {
+	return s.signer.PublicKey()
+}
+
+func (s *sshAlgorithmSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return s.signer.SignWithAlgorithm(rand, data, s.algorithm)
+}
+
+func getSignatureAlgorithm(publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki.SignatureAlgorithm) (algorithm string, err error) {
+	switch publicAlgo {
+	case crypki.RSA:
+		{
+			switch signAlgo {
+			case crypki.ECDSAWithSHA256, crypki.ECDSAWithSHA384:
+				err = errors.New("public key algo & signature algo mismatch, unable to get AlgorithmSigner")
+			case crypki.SHAWithRSA:
+				algorithm = ssh.SigAlgoRSA
+			case crypki.SHA512WithRSA:
+				algorithm = ssh.SigAlgoRSASHA2512
+			case crypki.SHA256WithRSA:
+				algorithm = ssh.SigAlgoRSASHA2256
+			default:
+				algorithm = ssh.SigAlgoRSASHA2256
+			}
+		}
+	case crypki.ECDSA:
+		{
+			// For ECDSA public algorithm, signature algo does not exist. We pass in
+			// empty algorithm & the upstream code will ensure the right algorithm is chosen
+			// for signing the cert.
+			switch signAlgo {
+			case crypki.ECDSAWithSHA256, crypki.ECDSAWithSHA384:
+				return
+			case crypki.SHAWithRSA, crypki.SHA256WithRSA, crypki.SHA512WithRSA:
+				err = errors.New("public key algo & signature algo mismatch, unable to get AlgorithmSigner")
+			default:
+			}
+		}
+	default:
+		err = errors.New("public key algorithm not supported")
+	}
+	return
+}
+
+func newAlgorithmSignerFromSigner(signer crypto.Signer, publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki.SignatureAlgorithm) (ssh.Signer, error) {
+	sshSigner, err := ssh.NewSignerFromSigner(signer)
+	if err != nil {
+		return nil, err
+	}
+	algorithmSigner, ok := sshSigner.(ssh.AlgorithmSigner)
+	if !ok {
+		return nil, errors.New("unable to cast to ssh.AlgorithmSigner")
+	}
+	algorithm, err := getSignatureAlgorithm(publicAlgo, signAlgo)
+	if err != nil {
+		return nil, err
+	}
+	s := sshAlgorithmSigner{
+		signer:    algorithmSigner,
+		algorithm: algorithm,
+	}
+	return &s, nil
+}

--- a/pkcs11/algosigner_test.go
+++ b/pkcs11/algosigner_test.go
@@ -47,6 +47,12 @@ func TestGetSignatureAlgorithm(t *testing.T) {
 			want:      "",
 			wantError: true,
 		},
+		"rsa pub no signing algo": {
+			pubAlgo:   crypki.RSA,
+			signAlgo:  crypki.UnknownSignatureAlgorithm,
+			want:      ssh.SigAlgoRSASHA2256,
+			wantError: false,
+		},
 		"ec pub ec sign": {
 			pubAlgo:   crypki.ECDSA,
 			signAlgo:  crypki.ECDSAWithSHA384,
@@ -56,6 +62,12 @@ func TestGetSignatureAlgorithm(t *testing.T) {
 		"ec pub rsa sign": {
 			pubAlgo:   crypki.ECDSA,
 			signAlgo:  crypki.SHA512WithRSA,
+			want:      "",
+			wantError: true,
+		},
+		"default pub key algo": {
+			pubAlgo:   crypki.UnknownPublicKeyAlgorithm,
+			signAlgo:  crypki.UnknownSignatureAlgorithm,
 			want:      "",
 			wantError: true,
 		},

--- a/pkcs11/algosigner_test.go
+++ b/pkcs11/algosigner_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pkcs11
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/theparanoids/crypki"
+)
+
+func TestGetSignatureAlgorithm(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		pubAlgo   crypki.PublicKeyAlgorithm
+		signAlgo  crypki.SignatureAlgorithm
+		want      string
+		wantError bool
+	}{
+		"rsa pub rsa 256 signing": {
+			pubAlgo:   crypki.RSA,
+			signAlgo:  crypki.SHA256WithRSA,
+			want:      ssh.SigAlgoRSASHA2256,
+			wantError: false,
+		},
+		"rsa pub rsa 512 signing": {
+			pubAlgo:   crypki.RSA,
+			signAlgo:  crypki.SHA512WithRSA,
+			want:      ssh.SigAlgoRSASHA2512,
+			wantError: false,
+		},
+		"rsa pub ec signing": {
+			pubAlgo:   crypki.RSA,
+			signAlgo:  crypki.ECDSAWithSHA384,
+			want:      "",
+			wantError: true,
+		},
+		"ec pub ec sign": {
+			pubAlgo:   crypki.ECDSA,
+			signAlgo:  crypki.ECDSAWithSHA384,
+			want:      "",
+			wantError: false,
+		},
+		"ec pub rsa sign": {
+			pubAlgo:   crypki.ECDSA,
+			signAlgo:  crypki.SHA512WithRSA,
+			want:      "",
+			wantError: true,
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			got, err := getSignatureAlgorithm(tt.pubAlgo, tt.signAlgo)
+			if (err != nil) != tt.wantError {
+				t.Errorf("%s: got %s want %s", name, got, tt.want)
+			}
+			if got != tt.want {
+				t.Errorf("%s: got %s want %s", name, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkcs11/algosigner_test.go
+++ b/pkcs11/algosigner_test.go
@@ -41,6 +41,12 @@ func TestGetSignatureAlgorithm(t *testing.T) {
 			want:      ssh.SigAlgoRSASHA2512,
 			wantError: false,
 		},
+		"rsa pub sha1 signing": {
+			pubAlgo:   crypki.RSA,
+			signAlgo:  crypki.SHAWithRSA,
+			want:      ssh.SigAlgoRSA,
+			wantError: false,
+		},
 		"rsa pub ec signing": {
 			pubAlgo:   crypki.RSA,
 			signAlgo:  crypki.ECDSAWithSHA384,

--- a/pkcs11/algosigner_test.go
+++ b/pkcs11/algosigner_test.go
@@ -59,12 +59,6 @@ func TestGetSignatureAlgorithm(t *testing.T) {
 			want:      "",
 			wantError: false,
 		},
-		"ec pub rsa sign": {
-			pubAlgo:   crypki.ECDSA,
-			signAlgo:  crypki.SHA512WithRSA,
-			want:      "",
-			wantError: true,
-		},
 		"default pub key algo": {
 			pubAlgo:   crypki.UnknownPublicKeyAlgorithm,
 			signAlgo:  crypki.UnknownSignatureAlgorithm,

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -209,7 +209,7 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
 
-	sshSigner, err := ssh.NewSignerFromSigner(signer)
+	sshSigner, err := newAlgorithmSignerFromSigner(signer, signer.publicKeyAlgorithm(), signer.signAlgorithm())
 	if err != nil {
 		return nil, fmt.Errorf("failed to new ssh signer from signer, error :%v", err)
 	}


### PR DESCRIPTION
With the latest OpenSSH & Mac update signature algo ssh-rsa is not supported. This change, uses the signature algo configured during server setup.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
