### PR TITLE
change from using crypki.PublicKey/SignAlgo to x509.PublicKey/SignAlgo

### DIFF
--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -84,8 +85,8 @@ func main() {
 			SlotNumber:             uint(cc.SlotNumber),
 			UserPinPath:            cc.UserPinPath,
 			KeyLabel:               cc.KeyLabel,
-			KeyType:                crypki.PublicKeyAlgorithm(cc.KeyType),
-			SignatureAlgo:          crypki.SignatureAlgorithm(cc.SignatureAlgo),
+			KeyType:                x509.PublicKeyAlgorithm(cc.KeyType),
+			SignatureAlgo:          x509.SignatureAlgorithm(cc.SignatureAlgo),
 			SessionPoolSize:        2,
 			X509CACertLocation:     "/tmp/509_ca.crt",
 			CreateCACertIfNotExist: true,

--- a/config/config.go
+++ b/config/config.go
@@ -5,13 +5,12 @@ package config
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/theparanoids/crypki"
 )
 
 const (
@@ -22,8 +21,8 @@ const (
 	defaultTLSHost           = ""
 	defaultTLSPort           = "4443"
 	defaultPoolSize          = 2
-	defaultKeyType           = crypki.RSA
-	defaultSignatureAlgo     = crypki.SHA256WithRSA
+	defaultKeyType           = x509.RSA
+	defaultSignatureAlgo     = x509.SHA256WithRSA
 
 	defaultShutdownOnSigningFailureConsecutiveCount    = 4
 	defaultShutdownOnSigningFailureTimerDurationSecond = 60
@@ -83,9 +82,9 @@ type KeyConfig struct {
 	// SessionPoolSize specifies the number of sessions that are opened for this key.
 	SessionPoolSize int
 	// KeyType specifies the type of key, such as RSA or ECDSA.
-	KeyType crypki.PublicKeyAlgorithm
+	KeyType x509.PublicKeyAlgorithm
 	// SignatureAlgo specifies the type of signature hash function such as SHA256WithRSA or ECDSAWithSHA384.
-	SignatureAlgo crypki.SignatureAlgorithm
+	SignatureAlgo x509.SignatureAlgorithm
 
 	// Below are configs of x509 extensions for this key. Useful when this key will be used
 	// for signing x509 certificates.
@@ -183,11 +182,11 @@ func (c *Config) validate() error {
 			return fmt.Errorf("key %q: CA cert is supposed to be created if it doesn't exist but X509CACertLocation is not specified", key.Identifier)
 		}
 
-		if key.KeyType < crypki.RSA || key.KeyType > crypki.ECDSA {
+		if key.KeyType < x509.RSA || key.KeyType > x509.Ed25519 {
 			return fmt.Errorf("key %q: invalid Key type specified", key.Identifier)
 		}
 
-		if key.SignatureAlgo < crypki.SHA256WithRSA || key.SignatureAlgo > crypki.ECDSAWithSHA384 {
+		if key.SignatureAlgo < x509.SHA256WithRSA || key.SignatureAlgo > x509.PureEd25519 {
 			return fmt.Errorf("key %q: invalid signature hash algo specified", key.Identifier)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -254,7 +254,6 @@ func (c *Config) loadDefaults() {
 	if c.ShutdownOnInternalFailureCriteria.TimerCountLimit == 0 {
 		c.ShutdownOnInternalFailureCriteria.TimerCountLimit = defaultShutdownOnSigningFailureTimerCount
 	}
-
 	if c.IdleTimeout == 0 {
 		c.IdleTimeout = defaultIdleTimeout
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,9 +19,9 @@ func TestParse(t *testing.T) {
 		TLSPort:           "4443",
 		SignersPerPool:    2,
 		Keys: []KeyConfig{
-			{"key1", 1, "", "/path/1", "foo", 2, 2, 3, []string{}, []string{}, true, "/path/foo", "", "", "", "", "", "My CA", 0},
-			{"key2", 2, "", "/path/2", "bar", 2, 1, 1, []string{"http://test.ocsp.com:8888"}, []string{"http://test.crl.com:8889"}, false, "", "", "", "", "", "", "", 0},
-			{"key3", 0, "foo", "/path/3", "baz", 2, 1, 1, []string{"http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"}, []string{"http://test1.crl.com:8889", "http://test2.crl.com:8889"}, false, "/path/baz", "", "", "", "", "", "", 0},
+			{"key1", 1, "", "/path/1", "foo", 2, 3, 10, []string{}, []string{}, true, "/path/foo", "", "", "", "", "", "My CA", 0},
+			{"key2", 2, "", "/path/2", "bar", 2, 1, 4, []string{"http://test.ocsp.com:8888"}, []string{"http://test.crl.com:8889"}, false, "", "", "", "", "", "", "", 0},
+			{"key3", 0, "foo", "/path/3", "baz", 2, 1, 4, []string{"http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"}, []string{"http://test1.crl.com:8889", "http://test2.crl.com:8889"}, false, "/path/baz", "", "", "", "", "", "", 0},
 		},
 		KeyUsages: []KeyUsage{
 			{"/sig/x509-cert", []string{"key1", "key3"}, 3600, true},

--- a/config/testdata/testconf-bad-endpoints.json
+++ b/config/testdata/testconf-bad-endpoints.json
@@ -2,7 +2,7 @@
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",
   "Keys": [
-    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":1, "SignatureAlgo": 2, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
+    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":1, "SignatureAlgo": 4, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
     {"Identifier": "key2", "KeyLabel": "bar", "SlotNumber": 2, "UserPinPath" : "/path/2"},
     {"Identifier": "key3", "KeyLabel": "baz", "SlotNumber": 3, "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz"}
   ],

--- a/config/testdata/testconf-bad-unknown-signature-algo.json
+++ b/config/testdata/testconf-bad-unknown-signature-algo.json
@@ -2,7 +2,7 @@
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",
   "Keys": [
-    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":1, "SignatureAlgo": 14, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
+    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":1, "SignatureAlgo": 22, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
     {"Identifier": "key2", "KeyLabel": "bar", "SlotNumber": 2, "UserPinPath" : "/path/2"},
     {"Identifier": "key3", "KeyLabel": "baz", "SlotNumber": 3, "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz"}
   ],

--- a/config/testdata/testconf-bad-unsupported-key-type.json
+++ b/config/testdata/testconf-bad-unsupported-key-type.json
@@ -2,7 +2,7 @@
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",
   "Keys": [
-    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":3, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
+    {"Identifier": "key1", "KeyLabel": "foo", "KeyType":5, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA"},
     {"Identifier": "key2", "KeyLabel": "bar", "SlotNumber": 2, "UserPinPath" : "/path/2"},
     {"Identifier": "key3", "KeyLabel": "baz", "SlotNumber": 3, "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz"}
   ],

--- a/config/testdata/testconf-good.json
+++ b/config/testdata/testconf-good.json
@@ -2,9 +2,9 @@
   "TLSClientAuthMode": 4,
   "X509CACertLocation":"testdata/cacert.pem",
   "Keys": [
-    {"Identifier": "key1", "KeyLabel": "foo", "KeyType": 2, "SignatureAlgo": 3, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA", "OCSPServers": [], "CRLDistributionPoints": []},
-    {"Identifier": "key2", "KeyLabel": "bar", "KeyType": 1, "SignatureAlgo": 1, "SlotNumber": 2, "UserPinPath" : "/path/2", "OCSPServers": ["http://test.ocsp.com:8888"], "CRLDistributionPoints": ["http://test.crl.com:8889"]},
-    {"Identifier": "key3", "KeyLabel": "baz", "KeyType": 1, "SignatureAlgo": 1, "SlotNumber": 0, "TokenLabel": "foo", "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz", "OCSPServers": ["http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"], "CRLDistributionPoints": ["http://test1.crl.com:8889", "http://test2.crl.com:8889"]}
+    {"Identifier": "key1", "KeyLabel": "foo", "KeyType": 3, "SignatureAlgo": 10, "SlotNumber": 1, "UserPinPath" : "/path/1", "X509CACertLocation": "/path/foo", "CreateCACertIfNotExist": true, "CommonName": "My CA", "OCSPServers": [], "CRLDistributionPoints": []},
+    {"Identifier": "key2", "KeyLabel": "bar", "KeyType": 1, "SignatureAlgo": 4, "SlotNumber": 2, "UserPinPath" : "/path/2", "OCSPServers": ["http://test.ocsp.com:8888"], "CRLDistributionPoints": ["http://test.crl.com:8889"]},
+    {"Identifier": "key3", "KeyLabel": "baz", "KeyType": 1, "SignatureAlgo": 4, "SlotNumber": 0, "TokenLabel": "foo", "UserPinPath" : "/path/3", "X509CACertLocation": "/path/baz", "OCSPServers": ["http://test1.ocsp.com:8888", "http://test2.ocsp.com:8888"], "CRLDistributionPoints": ["http://test1.crl.com:8889", "http://test2.crl.com:8889"]}
   ],
   "KeyUsages": [
     {"Endpoint": "/sig/x509-cert", "Identifiers": ["key1", "key3"], "MaxValidity": 3600, "PrioritySchedulingEnabled": true},

--- a/crypki.go
+++ b/crypki.go
@@ -26,30 +26,6 @@ const (
 	UserSSHKey
 )
 
-// PublicKeyAlgorithm is used to specify public key algorithm.
-type PublicKeyAlgorithm int
-
-// SignatureAlgorithm is used to specify signature key algorithm.
-type SignatureAlgorithm int
-
-// List of supported public key algorithms.
-const (
-	UnknownPublicKeyAlgorithm PublicKeyAlgorithm = iota
-	RSA
-	ECDSA
-)
-
-// List of supported signature hash algorithms.
-// The naming convention adheres to x509.SignatureAlgorithm.
-const (
-	UnknownSignatureAlgorithm SignatureAlgorithm = iota
-	SHA256WithRSA
-	ECDSAWithSHA256
-	ECDSAWithSHA384
-	SHA512WithRSA
-	SHAWithRSA // for backward compatibility
-)
-
 const (
 	// Default values for CAconfig.
 	defaultCounty         = "ZZ" // Unknown or unspecified country

--- a/pkcs11/algosigner.go
+++ b/pkcs11/algosigner.go
@@ -15,12 +15,11 @@ package pkcs11
 
 import (
 	"crypto"
+	"crypto/x509"
 	"errors"
 	"io"
 
 	"golang.org/x/crypto/ssh"
-
-	"github.com/theparanoids/crypki"
 )
 
 type sshAlgorithmSigner struct {
@@ -36,24 +35,24 @@ func (s *sshAlgorithmSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, 
 	return s.signer.SignWithAlgorithm(rand, data, s.algorithm)
 }
 
-func getSignatureAlgorithm(publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki.SignatureAlgorithm) (algorithm string, err error) {
+func getSignatureAlgorithm(publicAlgo x509.PublicKeyAlgorithm, signAlgo x509.SignatureAlgorithm) (algorithm string, err error) {
 	switch publicAlgo {
-	case crypki.RSA:
+	case x509.RSA:
 		{
 			switch signAlgo {
-			case crypki.ECDSAWithSHA256, crypki.ECDSAWithSHA384:
+			case x509.ECDSAWithSHA256, x509.ECDSAWithSHA384:
 				err = errors.New("public key algo & signature algo mismatch, unable to get AlgorithmSigner")
-			case crypki.SHAWithRSA:
+			case x509.SHA1WithRSA:
 				algorithm = ssh.SigAlgoRSA
-			case crypki.SHA512WithRSA:
+			case x509.SHA512WithRSA:
 				algorithm = ssh.SigAlgoRSASHA2512
-			case crypki.SHA256WithRSA:
+			case x509.SHA256WithRSA:
 				algorithm = ssh.SigAlgoRSASHA2256
 			default:
 				algorithm = ssh.SigAlgoRSASHA2256
 			}
 		}
-	case crypki.ECDSA:
+	case x509.ECDSA:
 		// For ECDSA public algorithm, signature algo does not exist. We pass in
 		// empty algorithm & the crypto library will ensure the right algorithm is chosen
 		// for signing the cert.
@@ -64,7 +63,7 @@ func getSignatureAlgorithm(publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki
 	return
 }
 
-func newAlgorithmSignerFromSigner(signer crypto.Signer, publicAlgo crypki.PublicKeyAlgorithm, signAlgo crypki.SignatureAlgorithm) (ssh.Signer, error) {
+func newAlgorithmSignerFromSigner(signer crypto.Signer, publicAlgo x509.PublicKeyAlgorithm, signAlgo x509.SignatureAlgorithm) (ssh.Signer, error) {
 	sshSigner, err := ssh.NewSignerFromSigner(signer)
 	if err != nil {
 		return nil, err

--- a/pkcs11/algosigner_test.go
+++ b/pkcs11/algosigner_test.go
@@ -14,60 +14,59 @@
 package pkcs11
 
 import (
+	"crypto/x509"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
-
-	"github.com/theparanoids/crypki"
 )
 
 func TestGetSignatureAlgorithm(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
-		pubAlgo   crypki.PublicKeyAlgorithm
-		signAlgo  crypki.SignatureAlgorithm
+		pubAlgo   x509.PublicKeyAlgorithm
+		signAlgo  x509.SignatureAlgorithm
 		want      string
 		wantError bool
 	}{
 		"rsa pub rsa 256 signing": {
-			pubAlgo:   crypki.RSA,
-			signAlgo:  crypki.SHA256WithRSA,
+			pubAlgo:   x509.RSA,
+			signAlgo:  x509.SHA256WithRSA,
 			want:      ssh.SigAlgoRSASHA2256,
 			wantError: false,
 		},
 		"rsa pub rsa 512 signing": {
-			pubAlgo:   crypki.RSA,
-			signAlgo:  crypki.SHA512WithRSA,
+			pubAlgo:   x509.RSA,
+			signAlgo:  x509.SHA512WithRSA,
 			want:      ssh.SigAlgoRSASHA2512,
 			wantError: false,
 		},
 		"rsa pub sha1 signing": {
-			pubAlgo:   crypki.RSA,
-			signAlgo:  crypki.SHAWithRSA,
+			pubAlgo:   x509.RSA,
+			signAlgo:  x509.SHA1WithRSA,
 			want:      ssh.SigAlgoRSA,
 			wantError: false,
 		},
 		"rsa pub ec signing": {
-			pubAlgo:   crypki.RSA,
-			signAlgo:  crypki.ECDSAWithSHA384,
+			pubAlgo:   x509.RSA,
+			signAlgo:  x509.ECDSAWithSHA384,
 			want:      "",
 			wantError: true,
 		},
 		"rsa pub no signing algo": {
-			pubAlgo:   crypki.RSA,
-			signAlgo:  crypki.UnknownSignatureAlgorithm,
+			pubAlgo:   x509.RSA,
+			signAlgo:  x509.UnknownSignatureAlgorithm,
 			want:      ssh.SigAlgoRSASHA2256,
 			wantError: false,
 		},
 		"ec pub ec sign": {
-			pubAlgo:   crypki.ECDSA,
-			signAlgo:  crypki.ECDSAWithSHA384,
+			pubAlgo:   x509.ECDSA,
+			signAlgo:  x509.ECDSAWithSHA384,
 			want:      "",
 			wantError: false,
 		},
 		"default pub key algo": {
-			pubAlgo:   crypki.UnknownPublicKeyAlgorithm,
-			signAlgo:  crypki.UnknownSignatureAlgorithm,
+			pubAlgo:   x509.UnknownPublicKeyAlgorithm,
+			signAlgo:  x509.UnknownSignatureAlgorithm,
 			want:      "",
 			wantError: true,
 		},

--- a/pkcs11/ecdsa.go
+++ b/pkcs11/ecdsa.go
@@ -100,7 +100,7 @@ func publicECDSA(s *p11Signer) crypto.PublicKey {
 func signDataECDSA(ctx PKCS11Ctx, session p11.SessionHandle, hsmPrivateObject p11.ObjectHandle, data []byte, opts crypto.SignerOpts) ([]byte, error) {
 	const MAXBYTES = 262042
 	if len(data) > MAXBYTES {
-		return nil, errors.New("Cannot sign such a large blob of data")
+		return nil, errors.New("cannot sign such a large blob of data")
 	}
 
 	privateKeyHandle := hsmPrivateObject
@@ -112,7 +112,7 @@ func signDataECDSA(ctx PKCS11Ctx, session p11.SessionHandle, hsmPrivateObject p1
 	case crypto.SHA1, crypto.SHA256, crypto.SHA384, crypto.SHA512:
 		mech[0] = p11.NewMechanism(p11.CKM_ECDSA, nil)
 	default:
-		return nil, errors.New("Unsupported hash algorithm")
+		return nil, errors.New("unsupported hash algorithm")
 	}
 
 	err := ctx.SignInit(session, mech, privateKeyHandle)

--- a/pkcs11/p11signer.go
+++ b/pkcs11/p11signer.go
@@ -5,13 +5,12 @@ package pkcs11
 
 import (
 	"crypto"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 
 	p11 "github.com/miekg/pkcs11"
-
-	"github.com/theparanoids/crypki"
 )
 
 type p11Signer struct {
@@ -19,11 +18,11 @@ type p11Signer struct {
 	session       p11.SessionHandle
 	privateKey    p11.ObjectHandle
 	publicKey     p11.ObjectHandle
-	keyType       crypki.PublicKeyAlgorithm
-	signatureAlgo crypki.SignatureAlgorithm
+	keyType       x509.PublicKeyAlgorithm
+	signatureAlgo x509.SignatureAlgorithm
 }
 
-func makeSigner(context PKCS11Ctx, slot uint, tokenLabel string, keyType crypki.PublicKeyAlgorithm, signatureAlgo crypki.SignatureAlgorithm) (*p11Signer, error) {
+func makeSigner(context PKCS11Ctx, slot uint, tokenLabel string, keyType x509.PublicKeyAlgorithm, signatureAlgo x509.SignatureAlgorithm) (*p11Signer, error) {
 	session, err := context.OpenSession(slot, p11.CKF_SERIAL_SESSION)
 	if err != nil {
 		return nil, errors.New("makeSigner: error in OpenSession: " + err.Error())
@@ -56,9 +55,9 @@ func makeSigner(context PKCS11Ctx, slot uint, tokenLabel string, keyType crypki.
 // Sign signs the data using PKCS11 library. It is part of the crypto.Signer interface.
 func (s *p11Signer) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
 	switch s.keyType {
-	case crypki.RSA:
+	case x509.RSA:
 		return signDataRSA(s.context, s.session, s.privateKey, msg, opts)
-	case crypki.ECDSA:
+	case x509.ECDSA:
 		return signDataECDSA(s.context, s.session, s.privateKey, msg, opts)
 	default: // RSA is the default
 		return signDataRSA(s.context, s.session, s.privateKey, msg, opts)
@@ -69,9 +68,9 @@ func (s *p11Signer) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]
 // Public returns crypto public key.
 func (s *p11Signer) Public() crypto.PublicKey {
 	switch s.keyType {
-	case crypki.RSA:
+	case x509.RSA:
 		return publicRSA(s)
-	case crypki.ECDSA:
+	case x509.ECDSA:
 		return publicECDSA(s)
 	default: // RSA is the default
 		return publicRSA(s)
@@ -79,11 +78,11 @@ func (s *p11Signer) Public() crypto.PublicKey {
 }
 
 // publicKeyAlgorithm returns the public key algorithm of signer.
-func (s *p11Signer) publicKeyAlgorithm() crypki.PublicKeyAlgorithm {
+func (s *p11Signer) publicKeyAlgorithm() x509.PublicKeyAlgorithm {
 	return s.keyType
 }
 
 // signAlgorithm returns the signature algorithm of signer.
-func (s *p11Signer) signAlgorithm() crypki.SignatureAlgorithm {
+func (s *p11Signer) signAlgorithm() x509.SignatureAlgorithm {
 	return s.signatureAlgo
 }

--- a/pkcs11/p11signer_test.go
+++ b/pkcs11/p11signer_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/asn1"
 	"errors"
 	"math/big"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	p11 "github.com/miekg/pkcs11"
-	"github.com/theparanoids/crypki"
 	"github.com/theparanoids/crypki/pkcs11/mock_pkcs11"
 )
 
@@ -115,7 +115,7 @@ func TestSignRSA(t *testing.T) {
 			defer mockctrl.Finish()
 
 			mockCtx := mock_pkcs11.NewMockPKCS11Ctx(mockctrl)
-			signer := &p11Signer{mockCtx, 0, 0, 0, crypki.RSA, crypki.SHA256WithRSA}
+			signer := &p11Signer{mockCtx, 0, 0, 0, x509.RSA, x509.SHA256WithRSA}
 
 			mockCtx.EXPECT().
 				SignInit(gomock.Any(), []*p11.Mechanism{p11.NewMechanism(p11.CKM_RSA_PKCS, nil)}, gomock.Any()).
@@ -243,7 +243,7 @@ func TestSignECDSA(t *testing.T) {
 			defer mockctrl.Finish()
 
 			mockCtx := mock_pkcs11.NewMockPKCS11Ctx(mockctrl)
-			signer := &p11Signer{mockCtx, 0, 0, 0, crypki.ECDSA, crypki.ECDSAWithSHA256}
+			signer := &p11Signer{mockCtx, 0, 0, 0, x509.ECDSA, x509.ECDSAWithSHA256}
 
 			mockCtx.EXPECT().
 				SignInit(gomock.Any(), []*p11.Mechanism{p11.NewMechanism(p11.CKM_ECDSA, nil)}, gomock.Any()).

--- a/pkcs11/pkcs11.go
+++ b/pkcs11/pkcs11.go
@@ -4,6 +4,7 @@
 package pkcs11
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
 
@@ -116,5 +117,5 @@ type KeyInfo struct {
 	// SignersPerPool is the number of signers we assign on a specific key
 	SignersPerPool int
 	// KeyType specifies the type of key, such as RSA or ECDSA.
-	KeyType crypki.PublicKeyAlgorithm
+	KeyType x509.PublicKeyAlgorithm
 }

--- a/pkcs11/rsa.go
+++ b/pkcs11/rsa.go
@@ -61,7 +61,7 @@ func publicRSA(s *p11Signer) crypto.PublicKey {
 func signDataRSA(ctx PKCS11Ctx, session p11.SessionHandle, hsmPrivateObject p11.ObjectHandle, data []byte, opts crypto.SignerOpts) ([]byte, error) {
 	const MAXBYTES = 262042
 	if len(data) > MAXBYTES {
-		return nil, errors.New("Cannot sign such a large blob of data")
+		return nil, errors.New("cannot sign such a large blob of data")
 	}
 
 	privateKeyHandle := hsmPrivateObject
@@ -78,7 +78,7 @@ func signDataRSA(ctx PKCS11Ctx, session p11.SessionHandle, hsmPrivateObject p11.
 		buf = append(hashPrefixes[hash], data...)
 		mech[0] = p11.NewMechanism(p11.CKM_RSA_PKCS, nil)
 	default:
-		return nil, errors.New("Unsupported hash algorithm")
+		return nil, errors.New("unsupported hash algorithm")
 	}
 
 	err := ctx.SignInit(session, mech, privateKeyHandle)

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -262,7 +262,7 @@ func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Reques
 		log.Printf("signX509cert: cn=%q unsupported-sa=%q supported-sa=%d",
 			s.x509CACerts[keyIdentifier].Subject.CommonName, cert.SignatureAlgorithm.String(), signer.signAlgorithm())
 		// Not a valid signature algorithm. Overwrite it with what the configured keyType supports.
-		cert.SignatureAlgorithm = x509cert.GetSignatureAlgorithm(signer.signAlgorithm())
+		cert.SignatureAlgorithm = signer.signAlgorithm()
 	}
 
 	cert.OCSPServer = s.ocspServers[keyIdentifier]
@@ -387,6 +387,6 @@ func getX509CACert(ctx context.Context, key config.KeyConfig, pool sPool, hostna
 	return cert, nil
 }
 
-func isValidCertRequest(cert *x509.Certificate, sa crypki.SignatureAlgorithm) bool {
-	return cert.SignatureAlgorithm == x509cert.GetSignatureAlgorithm(sa)
+func isValidCertRequest(cert *x509.Certificate, sa x509.SignatureAlgorithm) bool {
+	return cert.SignatureAlgorithm == sa
 }

--- a/pkcs11/signerpool.go
+++ b/pkcs11/signerpool.go
@@ -6,9 +6,8 @@ package pkcs11
 import (
 	"context"
 	"crypto"
+	"crypto/x509"
 	"fmt"
-
-	"github.com/theparanoids/crypki"
 )
 
 // sPool is an abstract interface of pool of crypto.Signer
@@ -19,8 +18,8 @@ type sPool interface {
 
 type signerWithSignAlgorithm interface {
 	crypto.Signer
-	publicKeyAlgorithm() crypki.PublicKeyAlgorithm
-	signAlgorithm() crypki.SignatureAlgorithm
+	publicKeyAlgorithm() x509.PublicKeyAlgorithm
+	signAlgorithm() x509.SignatureAlgorithm
 }
 
 // SignerPool is a pool of PKCS11 signers
@@ -30,7 +29,7 @@ type SignerPool struct {
 }
 
 // newSignerPool initializes a signer pool based on the configuration parameters
-func newSignerPool(context PKCS11Ctx, nSigners int, slot uint, keyLabel string, keyType crypki.PublicKeyAlgorithm, signatureAlgo crypki.SignatureAlgorithm) (sPool, error) {
+func newSignerPool(context PKCS11Ctx, nSigners int, slot uint, keyLabel string, keyType x509.PublicKeyAlgorithm, signatureAlgo x509.SignatureAlgorithm) (sPool, error) {
 	signers := make(chan signerWithSignAlgorithm, nSigners)
 	for i := 0; i < nSigners; i++ {
 		signerInstance, err := makeSigner(context, slot, keyLabel, keyType, signatureAlgo)

--- a/x509cert/x509.go
+++ b/x509cert/x509.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GenCACert creates the CA certificate given signer.
-func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, ips []net.IP, pka crypki.PublicKeyAlgorithm, sa crypki.SignatureAlgorithm) ([]byte, error) {
+func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, ips []net.IP, pka x509.PublicKeyAlgorithm, sa x509.SignatureAlgorithm) ([]byte, error) {
 	// Backdate start time by one hour as the current system clock may be ahead of other running systems.
 	start := uint64(time.Now().Unix())
 	end := start + config.ValidityPeriod
@@ -51,9 +51,9 @@ func GenCACert(config *crypki.CAConfig, signer crypto.Signer, hostname string, i
 	template := &x509.Certificate{
 		Subject:               subj,
 		SerialNumber:          newSerial(),
-		PublicKeyAlgorithm:    GetPublicKeyAlgorithm(pka),
+		PublicKeyAlgorithm:    pka,
 		PublicKey:             signer.Public(),
-		SignatureAlgorithm:    GetSignatureAlgorithm(sa),
+		SignatureAlgorithm:    sa,
 		NotBefore:             time.Unix(int64(start), 0),
 		NotAfter:              time.Unix(int64(end), 0),
 		DNSNames:              []string{hostname},
@@ -73,30 +73,4 @@ func newSerial() *big.Int {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
 	return serialNumber
-}
-
-// GetSignatureAlgorithm returns x509 Signature algorithm corresponding to signature algorithm received as part of CSR.
-func GetSignatureAlgorithm(sa crypki.SignatureAlgorithm) x509.SignatureAlgorithm {
-	algo := x509.SHA256WithRSA
-	switch sa {
-	case crypki.SHA256WithRSA:
-		algo = x509.SHA256WithRSA
-	case crypki.ECDSAWithSHA256:
-		algo = x509.ECDSAWithSHA256
-	case crypki.ECDSAWithSHA384:
-		algo = x509.ECDSAWithSHA384
-	}
-	return algo
-}
-
-// GetPublicKeyAlgorithm returns the x509 Public algorithm corresponding to the public key algorithm received as part of CSR.
-func GetPublicKeyAlgorithm(pka crypki.PublicKeyAlgorithm) x509.PublicKeyAlgorithm {
-	algo := x509.RSA
-	switch pka {
-	case crypki.RSA:
-		algo = x509.RSA
-	case crypki.ECDSA:
-		algo = x509.ECDSA
-	}
-	return algo
 }

--- a/x509cert/x509_test.go
+++ b/x509cert/x509_test.go
@@ -17,66 +17,10 @@ import (
 	"github.com/theparanoids/crypki"
 )
 
-func TestGetSignatureAlgorithm(t *testing.T) {
-	t.Parallel()
-	tests := map[string]struct {
-		sa   crypki.SignatureAlgorithm
-		want x509.SignatureAlgorithm
-	}{
-		"rsa key & signature": {
-			sa:   crypki.SHA256WithRSA,
-			want: x509.SHA256WithRSA,
-		},
-		"ec key & 384 signature": {
-			sa:   crypki.ECDSAWithSHA384,
-			want: x509.ECDSAWithSHA384,
-		},
-		"ec key & 256 signature": {
-			sa:   crypki.ECDSAWithSHA256,
-			want: x509.ECDSAWithSHA256,
-		},
-		"no signature algo": {
-			sa:   crypki.UnknownSignatureAlgorithm,
-			want: x509.SHA256WithRSA,
-		},
-	}
-	for name, tt := range tests {
-		name, tt := name, tt
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			got := GetSignatureAlgorithm(tt.sa)
-			if got != tt.want {
-				t.Errorf("%s: got %d want %d", name, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetPublicKeyAlgorithm(t *testing.T) {
-	t.Parallel()
-	tests := map[string]struct {
-		pka  crypki.PublicKeyAlgorithm
-		want x509.PublicKeyAlgorithm
-	}{
-		"rsa":         {pka: crypki.RSA, want: x509.RSA},
-		"ec key":      {pka: crypki.ECDSA, want: x509.ECDSA},
-		"unknown key": {pka: crypki.UnknownPublicKeyAlgorithm, want: x509.RSA},
-	}
-	for name, tt := range tests {
-		name, tt := name, tt
-		t.Run(name, func(t *testing.T) {
-			got := GetPublicKeyAlgorithm(tt.pka)
-			if got != tt.want {
-				t.Fatalf("%s: got %d want %d", name, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGenCACert(t *testing.T) {
 	t.Parallel()
-	pka := crypki.ECDSA
-	sa := crypki.ECDSAWithSHA384
+	pka := x509.ECDSA
+	sa := x509.ECDSAWithSHA384
 	eckey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -86,8 +30,8 @@ func TestGenCACert(t *testing.T) {
 		signer      crypto.Signer
 		hostname    string
 		ips         []net.IP
-		pka         crypki.PublicKeyAlgorithm
-		sa          crypki.SignatureAlgorithm
+		pka         x509.PublicKeyAlgorithm
+		sa          x509.SignatureAlgorithm
 		wantSubj    pkix.Name
 		expectError bool
 	}{


### PR DESCRIPTION
This pull request uses the signature algorithm & public algorithm defined in the crypto library & removes the PublicAlgorithm & SignatureAlgorithm type from crypki. This change is backwards incompatible & the config needs to change in order to map the new values for PublicKeyAlgorithm & SignatureAlgorithm.

Mapping table:

| crypki Signature Algorithm value | Crypto library Signature Algorithm value |
| ------------------- | ----------------------------------- |
| SHA256WithRSA (1) | SHA256WithRSA(4) |
| ECDSAWithSHA256 (2) | ECDSAWithSHA256(10) |
| ECDSAWithSHA384 (3) | ECDSAWithSHA384(11) |
| SHA512WithRSA (4) | SHA512WithRSA(6) |
| SHA1WithRSA (5) | SHAWithRSA(3) |

| crypki Public Key Algorithm value | Crypto library Public Key Algorithm value |
| ------------------- | ----------------------------------- |
| RSA (1) | RSA (1) |
| ECDSA (2) | ECDSA (3) |

Note: Starting with OpenSSH > 8.6, signature algo SHA1WithRSA has been deprecated. We do not recommend using that signature algorithm for any signing operation.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
