### PR TITLE
handle special case when server is not running

### DIFF
--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -79,6 +79,13 @@ func getRemainingRequestTime(ctx context.Context, keyIdentifier string) (time.Du
 }
 
 func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority) (signer signerWithSignAlgorithm, err error) {
+	// Need to handle case when we directly invoke SignSSHCert or SignX509Cert for
+	// either generating the host certs or X509 CA certs. In that case we don't need the server
+	// running nor do we need to worry about priority scheduling. In that case, we immediately
+	// fetch the signer from the pool.
+	if requestChan == nil {
+		return pool.get(ctx)
+	}
 	remTime, err := getRemainingRequestTime(ctx, keyIdentifier)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is to handle the case when server is not running, but user needs to generate a host cert or x509 ca cert.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
