### PR TITLE
Cleanup extra logs. Increase default timeout for PKCS11. 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ const (
 	// BlobEndpoint specifies the endpoint for raw signing.
 	BlobEndpoint = "/sig/blob"
 	// DefaultPKCS11Timeout specifies the max time required by HSM to sign a cert.
-	DefaultPKCS11Timeout = 5 * time.Second
+	DefaultPKCS11Timeout = 10 * time.Second
 )
 
 var endpoints = map[string]bool{

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -104,15 +104,15 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 	select {
 	case requestChan <- scheduler.Request{Priority: priority, DoWorker: &Work{work: req}}:
 	case <-ctx.Done():
-		// channel closed
-		// this should ideally not happen but in order to avoid a blocking call we add this check in place
+		// channel closed.
+		// this should ideally not happen but in order to avoid a blocking call we add this check in place.
 		return nil, errors.New("request channel is closed, cannot fetch signer")
 	}
 	var ok bool
 	select {
 	case signer, ok = <-respChan:
 		if signer == nil || !ok {
-			return nil, errors.New("client request timed out, skip signing X509 cert")
+			return nil, errors.New("client request timed out, skip signing request")
 		}
 	case <-ctx.Done():
 		// In order to ensure we don't keep on blocking on the response, we add this check.

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -46,6 +46,7 @@ type Request struct {
 	identifier    string                       // identifier indicates the endpoint for which we are fetching the signer in order to sign it
 	remainingTime time.Duration                // remainingTime indicates the time remaining before either the client cancels or the request times out.
 	respChan      chan signerWithSignAlgorithm // respChan is the channel where the worker sends the signer once it gets it from the pool
+	reqStartTime  time.Time                    // reqStartTime indicates the time when the request for getting a signer was made
 }
 
 // signer implements crypki.CertSign interface.
@@ -78,7 +79,7 @@ func getRemainingRequestTime(ctx context.Context, keyIdentifier string) (time.Du
 	return remTime, nil
 }
 
-func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority) (signer signerWithSignAlgorithm, err error) {
+func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority, startTime time.Time) (signer signerWithSignAlgorithm, err error) {
 	// Need to handle case when we directly invoke SignSSHCert or SignX509Cert for
 	// either generating the host certs or X509 CA certs. In that case we don't need the server
 	// running nor do we need to worry about priority scheduling. In that case, we immediately
@@ -96,6 +97,7 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 		identifier:    keyIdentifier,
 		remainingTime: remTime,
 		respChan:      respChan,
+		reqStartTime:  startTime,
 	}
 	if priority == proto.Priority_Unspecified_priority {
 		// If priority is unspecified, treat the request as high priority.
@@ -104,8 +106,8 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 	select {
 	case requestChan <- scheduler.Request{Priority: priority, DoWorker: &Work{work: req}}:
 	case <-ctx.Done():
-		// channel closed.
-		// this should ideally not happen but in order to avoid a blocking call we add this check in place.
+		// Channel is closed.
+		// This should ideally not happen but in order to avoid a blocking call we add this check in place.
 		return nil, errors.New("request channel is closed, cannot fetch signer")
 	}
 	var ok bool
@@ -208,7 +210,7 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, pStart)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
@@ -256,7 +258,7 @@ func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Reques
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, pStart)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
@@ -321,7 +323,7 @@ func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, d
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, pStart)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err

--- a/server/scheduler/priority.go
+++ b/server/scheduler/priority.go
@@ -24,11 +24,8 @@ var statsTimer = 5 * time.Minute
 // CollectRequest is responsible for receiving work requests from the client & enqueues the request to the requestQueue as part of a go routine
 func CollectRequest(ctx context.Context, requestChan <-chan Request, p *Pool) {
 	// create new worker pool for the given endpoint
-	log.Printf("create worker pool for %q with size %d", p.Name, p.PoolSize)
 	p.initialize()
 	p.start(ctx)
-
-	log.Printf("start collecting requests for endpoint %q", p.Name)
 
 	go p.dumpStats(ctx, statsTimer)
 

--- a/server/scheduler/workerpool.go
+++ b/server/scheduler/workerpool.go
@@ -31,7 +31,7 @@ type Pool struct {
 	requestQueue   map[proto.Priority]chan *Request
 }
 
-// initialize initializes the worker Pool which has multiple workers & request queue map for queueing extra requests based on priority.
+// initialize initializes the worker pool which has multiple workers & request queue map for queueing extra requests based on priority.
 // This method creates different workers with different priorities. We currently create 4x high priority workers, 2x medium priority &
 // 1x low priority workers based on the signerPoolSize.
 func (p *Pool) initialize() {


### PR DESCRIPTION
This PR contains check to cleanup logs & ensure if client request times out, we should increment the timeout counter & return.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
