### PR TITLE
change timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ const (
 	// BlobEndpoint specifies the endpoint for raw signing.
 	BlobEndpoint = "/sig/blob"
 	// DefaultPKCS11Timeout specifies the max time required by HSM to sign a cert.
-	DefaultPKCS11Timeout = 5 * time.Second
+	DefaultPKCS11Timeout = 10 * time.Second
 )
 
 var endpoints = map[string]bool{


### PR DESCRIPTION
Change default PKCS11 timeout from 5 second to 10 second as downstream request currently uses a higher timeout. In a follow up PR make this timeout configurable.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
