### PR TITLE
add SAN `crypki` to tls server cert

### DIFF
--- a/docker-softhsm/gen-crt.sh
+++ b/docker-softhsm/gen-crt.sh
@@ -38,8 +38,9 @@ openssl \
 	-subj "/C=US/CN=localhost" \
   -out server.csr
 
-# sign server.csr by root CA 
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 36500 -sha256
+# sign server.csr by root CA
+# add SAN `crypki` for docker network access.
+openssl x509 -req -extfile <(printf "subjectAltName=DNS:crypki") -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 36500 -sha256
 
 
 # for mutual TLS


### PR DESCRIPTION
We are going to release RA (Registration Authority). To enable the mTLS between sshra container and crypki container, we add `crypki` to the SAN of tls server cert.

--
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
