### PR TITLE
resolve potential deadlock

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,6 @@ const (
 	defaultReadTimeout   = 10
 	defaultWriteTimeout  = 10
 	DefaultPKCS11Timeout = 10 // in seconds
-	DefaultHSMTimeout    = 10 // in seconds
 
 	// X509CertEndpoint specifies the endpoint for signing X509 certificate.
 	X509CertEndpoint = "/sig/x509-cert"

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,8 @@ const (
 	defaultIdleTimeout   = 30
 	defaultReadTimeout   = 10
 	defaultWriteTimeout  = 10
-	DefaultPKCS11Timeout = 10
+	DefaultPKCS11Timeout = 10 // in seconds
+	DefaultHSMTimeout    = 10 // in seconds
 
 	// X509CertEndpoint specifies the endpoint for signing X509 certificate.
 	X509CertEndpoint = "/sig/x509-cert"

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -42,10 +42,9 @@ import (
    It also has a channel on which it waits for the response.
 */
 type Request struct {
-	pool          sPool                        // pool is a signer pool per identifier from which to fetch the signer
-	identifier    string                       // identifier indicates the endpoint for which we are fetching the signer in order to sign it
-	remainingTime time.Duration                // remainingTime indicates the time remaining before either the client cancels or the request times out.
-	respChan      chan signerWithSignAlgorithm // respChan is the channel where the worker sends the signer once it gets it from the pool
+	pool       sPool                        // pool is a signer pool per identifier from which to fetch the signer
+	identifier string                       // identifier indicates the endpoint for which we are fetching the signer in order to sign it
+	respChan   chan signerWithSignAlgorithm // respChan is the channel where the worker sends the signer once it gets it from the pool
 }
 
 // signer implements crypki.CertSign interface.
@@ -67,19 +66,7 @@ type signer struct {
 	requestTimeout uint
 }
 
-func getRemainingRequestTime(ctx context.Context, keyIdentifier string, requestTimeout uint) (time.Duration, error) {
-	remTime := time.Duration(requestTimeout) * time.Second
-	if deadline, ok := ctx.Deadline(); ok {
-		remTime = time.Until(deadline)
-		if remTime <= 0 {
-			// context expired, we should stop processing and return immediately
-			return 0, fmt.Errorf("context deadline expired for key identifier %q", keyIdentifier)
-		}
-	}
-	return remTime, nil
-}
-
-func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority, requestTimeout uint) (signer signerWithSignAlgorithm, err error) {
+func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPool, keyIdentifier string, priority proto.Priority) (signer signerWithSignAlgorithm, err error) {
 	// Need to handle case when we directly invoke SignSSHCert or SignX509Cert for
 	// either generating the host certs or X509 CA certs. In that case we don't need the server
 	// running nor do we need to worry about priority scheduling. In that case, we immediately
@@ -87,16 +74,11 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 	if requestChan == nil {
 		return pool.get(ctx)
 	}
-	remTime, err := getRemainingRequestTime(ctx, keyIdentifier, requestTimeout)
-	if err != nil {
-		return nil, err
-	}
 	respChan := make(chan signerWithSignAlgorithm)
 	req := &Request{
-		pool:          pool,
-		identifier:    keyIdentifier,
-		remainingTime: remTime,
-		respChan:      respChan,
+		pool:       pool,
+		identifier: keyIdentifier,
+		respChan:   respChan,
 	}
 	if priority == proto.Priority_Unspecified_priority {
 		// If priority is unspecified, treat the request as high priority.
@@ -109,9 +91,16 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 		// This should ideally not happen but in order to avoid a blocking call we add this check in place.
 		return nil, errors.New("request channel is closed, cannot fetch signer")
 	}
-	signer, ok := <-respChan
-	if signer == nil || !ok {
-		return nil, errors.New("client request timed out, skip signing cert request")
+	var ok bool
+	select {
+	case signer, ok = <-respChan:
+		if signer == nil || !ok {
+			return nil, errors.New("client request timed out, skip signing cert request")
+		}
+	case <-ctx.Done():
+		// In order to ensure we don't keep on blocking on the response, we close the response channel for this request & return.
+		close(respChan)
+		return nil, ctx.Err()
 	}
 	return signer, nil
 }
@@ -204,19 +193,13 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, s.requestTimeout)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
 
 	sshSigner, err := newAlgorithmSignerFromSigner(signer, signer.publicKeyAlgorithm(), signer.signAlgorithm())
 	if err != nil {
@@ -258,19 +241,13 @@ func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Reques
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, s.requestTimeout)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
 
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(cert, signer.signAlgorithm()); !val {
@@ -329,19 +306,13 @@ func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, d
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
 	}
 	pStart := time.Now()
-	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority, s.requestTimeout)
+	signer, err := getSigner(ctx, reqChan, pool, keyIdentifier, priority)
 	if err != nil {
 		pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 		return nil, err
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
 
 	// measure time taken by hsm
 	hStart := time.Now()

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -212,6 +212,12 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
 
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	sshSigner, err := newAlgorithmSignerFromSigner(signer, signer.publicKeyAlgorithm(), signer.signAlgorithm())
 	if err != nil {
 		return nil, fmt.Errorf("failed to new ssh signer from signer, error :%v", err)
@@ -259,6 +265,12 @@ func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Reques
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(cert, signer.signAlgorithm()); !val {
@@ -324,6 +336,12 @@ func (s *signer) SignBlob(ctx context.Context, reqChan chan scheduler.Request, d
 	}
 	pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	defer pool.put(signer)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	// measure time taken by hsm
 	hStart := time.Now()

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -109,15 +109,9 @@ func getSigner(ctx context.Context, requestChan chan scheduler.Request, pool sPo
 		// This should ideally not happen but in order to avoid a blocking call we add this check in place.
 		return nil, errors.New("request channel is closed, cannot fetch signer")
 	}
-	var ok bool
-	select {
-	case signer, ok = <-respChan:
-		if signer == nil || !ok {
-			return nil, errors.New("client request timed out, skip signing cert request")
-		}
-	case <-ctx.Done():
-		// In order to ensure we don't keep on blocking on the response, we add this check.
-		return nil, ctx.Err()
+	signer, ok := <-respChan
+	if signer == nil || !ok {
+		return nil, errors.New("client request timed out, skip signing cert request")
 	}
 	return signer, nil
 }

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -113,7 +113,7 @@ func dummyScheduler(ctx context.Context, reqChan chan scheduler.Request) {
 		req := <-reqChan
 		go func() {
 			// create worker with different priorities
-			worker := &scheduler.Worker{ID: 1, Priority: req.Priority, Quit: make(chan struct{})}
+			worker := &scheduler.Worker{ID: 1, Priority: req.Priority, Quit: make(chan struct{}), HSMTimeout: 1 * time.Second}
 			req.DoWorker.DoWork(ctx, worker)
 		}()
 	}
@@ -336,7 +336,8 @@ func TestSignX509RSACert(t *testing.T) {
 	cp := x509.NewCertPool()
 	cp.AddCert(caCert)
 
-	ctx := context.Background()
+	ctx, cnc := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cnc()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -424,7 +425,8 @@ func TestSignX509ECCert(t *testing.T) {
 	cp := x509.NewCertPool()
 	cp.AddCert(caCert)
 
-	ctx := context.Background()
+	ctx, cnc := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cnc()
 	reqChan := make(chan scheduler.Request)
 	testcases := map[string]struct {
 		ctx         context.Context

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -36,7 +36,7 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 		reqCtx, cancel := context.WithTimeout(context.Background(), w.work.remainingTime)
 		defer cancel()
 		signer, err := w.work.pool.get(reqCtx)
-		if err != nil {
+		if signer == nil || err != nil {
 			worker.TotalTimeout.Inc()
 			log.Printf("%s: error fetching signer %v", worker.String(), err)
 			w.work.respChan <- nil

--- a/server/scheduler/worker.go
+++ b/server/scheduler/worker.go
@@ -61,7 +61,7 @@ func newWorker(workerId int, workerPriority proto.Priority) *Worker {
 	return &Worker{
 		ID:         workerId,
 		Priority:   workerPriority,
-		HSMTimeout: config.DefaultHSMTimeout * time.Second,
+		HSMTimeout: config.DefaultPKCS11Timeout * time.Second,
 		Quit:       make(chan struct{}),
 	}
 }

--- a/server/scheduler/worker.go
+++ b/server/scheduler/worker.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
+	"github.com/theparanoids/crypki/config"
 	"github.com/theparanoids/crypki/proto"
 )
 
@@ -36,6 +38,7 @@ type Request struct {
 type Worker struct {
 	ID             int            // ID is a unique id for the worker
 	Priority       proto.Priority // Priority indicates the priority of the request the worker is handling.
+	HSMTimeout     time.Duration  // HSMTimeout is the max time a worker can wait to get signer from pool.
 	TotalProcessed Counter        // TotalProcessed indicates the total requests processed per priority by this worker.
 	TotalTimeout   Counter        // TotalTimeout indicates the total requests that timed out before worker could process it.
 	Quit           chan struct{}  // Quit is a channel to cancel the worker
@@ -56,9 +59,10 @@ func (w *Worker) String() string {
 // that the worker can add itself to when it is idle. It also creates a slice for storing totalProcessed requests.
 func newWorker(workerId int, workerPriority proto.Priority) *Worker {
 	return &Worker{
-		ID:       workerId,
-		Priority: workerPriority,
-		Quit:     make(chan struct{}),
+		ID:         workerId,
+		Priority:   workerPriority,
+		HSMTimeout: config.DefaultHSMTimeout * time.Second,
+		Quit:       make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
When client cancels the request, server needs to stop processing any pending request for that client. This PR also handles the case where the worker does not indefinitely wait for fetching the signer from signer pool by assigning a timeout to it.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
