### PR TITLE
Cleanup code

### DIFF
--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -113,7 +113,7 @@ func dummyScheduler(ctx context.Context, reqChan chan scheduler.Request) {
 		req := <-reqChan
 		go func() {
 			// create worker with different priorities
-			worker := &scheduler.Worker{ID: 1, Priority: req.Priority, Quit: make(chan struct{}), HSMTimeout: 1 * time.Second}
+			worker := &scheduler.Worker{ID: 1, Priority: req.Priority, Quit: make(chan struct{}), PKCS11Timeout: 1 * time.Second}
 			req.DoWorker.DoWork(ctx, worker)
 		}()
 	}

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -28,10 +28,10 @@ type Work struct {
 
 // DoWork performs the work of fetching the signer from the pool and sending it back on the response channel.
 // If the client cancels the request or times out, the worker should not wait indefinitely for getting the signer
-// from the pool.We also have a PKCS11 timeout which is the maximum duration for which worker waits to fetch the
+// from the pool. We also have a PKCS11 timeout which is the maximum duration for which worker waits to fetch the
 // signer from pool & cancel the client request if it exceeds that.
 func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
-	reqCtx, cancel := context.WithTimeout(context.Background(), worker.HSMTimeout)
+	reqCtx, cancel := context.WithTimeout(context.Background(), worker.PKCS11Timeout)
 	type resp struct {
 		signer signerWithSignAlgorithm
 		err    error

--- a/server/scheduler/worker.go
+++ b/server/scheduler/worker.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/theparanoids/crypki/config"
 	"github.com/theparanoids/crypki/proto"
 )
 
@@ -38,7 +37,7 @@ type Request struct {
 type Worker struct {
 	ID             int            // ID is a unique id for the worker
 	Priority       proto.Priority // Priority indicates the priority of the request the worker is handling.
-	HSMTimeout     time.Duration  // HSMTimeout is the max time a worker can wait to get signer from pool.
+	PKCS11Timeout  time.Duration  // PKCS11Timeout is the max time a worker can wait to get signer from pool.
 	TotalProcessed Counter        // TotalProcessed indicates the total requests processed per priority by this worker.
 	TotalTimeout   Counter        // TotalTimeout indicates the total requests that timed out before worker could process it.
 	Quit           chan struct{}  // Quit is a channel to cancel the worker
@@ -57,12 +56,12 @@ func (w *Worker) String() string {
 
 // newWorker creates & returns a new worker object. Its argument is the workerId, the worker priority & a channel
 // that the worker can add itself to when it is idle. It also creates a slice for storing totalProcessed requests.
-func newWorker(workerId int, workerPriority proto.Priority) *Worker {
+func newWorker(workerId int, workerPriority proto.Priority, pkcs11Timeout time.Duration) *Worker {
 	return &Worker{
-		ID:         workerId,
-		Priority:   workerPriority,
-		HSMTimeout: config.DefaultPKCS11Timeout * time.Second,
-		Quit:       make(chan struct{}),
+		ID:            workerId,
+		Priority:      workerPriority,
+		PKCS11Timeout: pkcs11Timeout,
+		Quit:          make(chan struct{}),
 	}
 }
 

--- a/server/scheduler/workerpool.go
+++ b/server/scheduler/workerpool.go
@@ -27,6 +27,7 @@ type Pool struct {
 	Name           string
 	PoolSize       int
 	FeatureEnabled bool
+	PKCS11Timeout  time.Duration
 	workers        []*Worker
 	requestQueue   map[proto.Priority]chan *Request
 }
@@ -46,7 +47,7 @@ func (p *Pool) initialize() {
 	var i, j int
 	for pri, size := range mp {
 		for ; i < j+size; i++ {
-			worker := newWorker(i, pri)
+			worker := newWorker(i, pri, p.PKCS11Timeout)
 			p.workers = append(p.workers, worker)
 		}
 		j += size

--- a/server/server.go
+++ b/server/server.go
@@ -155,7 +155,7 @@ func Main() {
 		v := idEpMap[key.Identifier]
 		if !endpointMap[v.endpoint] {
 			endpointMap[v.endpoint] = true
-			p := &scheduler.Pool{Name: v.endpoint, PoolSize: key.SessionPoolSize, FeatureEnabled: v.priSchedFeature}
+			p := &scheduler.Pool{Name: v.endpoint, PoolSize: key.SessionPoolSize, FeatureEnabled: v.priSchedFeature, PKCS11Timeout: config.DefaultPKCS11Timeout * time.Second}
 			go scheduler.CollectRequest(ctx, requestChan[v.endpoint], p)
 		}
 	}


### PR DESCRIPTION
This PR cleans up reference of HSMTimeout with PKCS11Timeout and also cleans up misc code.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
