### PR TITLE
honor the client context timeout if its less than the request timeout

### DIFF
--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -122,9 +122,16 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// create a context with server side timeout
+	// Check if ctx passed as part of the client request has a deadline. If it does & it does not exceed the request
+	// timeout use that else use RequestTimeout.
 	reqCtx, cancel := context.WithTimeout(ctx, time.Duration(s.RequestTimeout)*time.Second)
-	defer cancel() // Cancel ctx as soon as PostUserSSHCertificate returns
+	if deadline, ok := ctx.Deadline(); ok {
+		remTime := time.Until(deadline)
+		if remTime < time.Duration(s.RequestTimeout) {
+			reqCtx, cancel = context.WithTimeout(ctx, remTime*time.Second)
+		}
+	}
+	defer cancel() // cancel ctx as soon as PostX509Certificate returns
 
 	maxValidity := s.MaxValidity[config.SSHUserCertEndpoint]
 	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -114,9 +114,16 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	// Create a context with server side timeout.
+	// Check if ctx passed as part of the client request has a deadline. If it does & it does not exceed the request
+	// timeout use that else use RequestTimeout.
 	reqCtx, cancel := context.WithTimeout(ctx, time.Duration(s.RequestTimeout)*time.Second)
-	defer cancel() // Cancel ctx as soon as PostX509Certificate returns
+	if deadline, ok := ctx.Deadline(); ok {
+		remTime := time.Until(deadline)
+		if remTime < time.Duration(s.RequestTimeout) {
+			reqCtx, cancel = context.WithTimeout(ctx, remTime*time.Second)
+		}
+	}
+	defer cancel() // cancel ctx as soon as PostX509Certificate returns
 
 	maxValidity := s.MaxValidity[config.X509CertEndpoint]
 	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {


### PR DESCRIPTION
This PR checks the client context. If it has a deadline associated with it, it will get the remaining time & check with the configured request timeout. If it is less than the request timeout, it will use that timeout for processing the request else it will use the request timeout.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
