### PR TITLE
use ec384 for ssh-user-cert & export signing public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ go mod vendor
 
 
 ## Configuration
+
 Take a look at the [sample configuration file](https://github.com/theparanoids/crypki/blob/main/config/testdata/testconf-good.json) to see how to configure crypki
 
 ## API
@@ -80,7 +81,7 @@ Get all available SSH signing keys
   curl -X GET https://localhost:4443/v3/sig/ssh-user-cert/keys --cert tls-crt/client.crt --key tls-crt/client.key --cacert tls-crt/ca.crt
    ```
 
-Get SSH user public signing key
+Get SSH user public signing key (CA public key for ssh-user-cert) 
   ```sh
   curl -X GET https://localhost:4443/v3/sig/ssh-user-cert/keys/ssh-user-key --cert tls-crt/client.crt --key tls-crt/client.key --cacert tls-crt/ca.crt
    ```
@@ -114,6 +115,24 @@ Sign blob (input is base64 encoded value of raw hash of a blob. [example code](h
   ```sh
   curl -X POST -H "Content-Type: application/json" https://localhost:4443/v3/sig/blob/keys/sign-blob-key --data @sign_blob.json --cert tls-crt/client.crt --key tls-crt/client.key --cacert tls-crt/ca.crt
   ```
+
+## CA credentials 
+
+### Extract SSH CA public key for key identifier 
+
+  > Note: [init_hsm.sh](./docker-softhsm/init_hsm.sh) extracts the public keys of each key slot from the SoftHSM, and stores inside the container.  
+  
+  Following script exports the public key (in PEM format) of slot `user_ssh_pub` from the container, and converts it into SSH format.    
+
+  ```sh
+   docker cp crypki:/opt/crypki/slot_pubkeys/user_ssh_pub.pem ~/tmp/user_ssh_pub.pem 
+   ssh-keygen -f ~/tmp/user_ssh_pub.pem -i -mPKCS8
+  ```
+
+<!---
+### Generate X509 CA certificate for key identifier `host_x509`
+TODO: Provide an example of binary `gen-cacert` usage
+-->
 
 ## Contribute
 

--- a/docker-softhsm/Dockerfile
+++ b/docker-softhsm/Dockerfile
@@ -16,19 +16,21 @@ FROM golang:1.16.2
 ENV CRYPKI_DIR /go/src/github.com/theparanoids/crypki
 COPY . ${CRYPKI_DIR}
 WORKDIR ${CRYPKI_DIR}
-RUN go get -v ./... && go test ./... && go build -o crypki-bin ${CRYPKI_DIR}/cmd/crypki
+RUN go get -v ./... && go test ./... && go build -o crypki-bin ${CRYPKI_DIR}/cmd/crypki && \
+    go build -o gen-cacert ${CRYPKI_DIR}/cmd/gen-cacert
 
 FROM debian:sid-slim
 ENV CRYPKI_DIR /go/src/github.com/theparanoids/crypki
 WORKDIR /opt/crypki
 
 COPY --from=0 ${CRYPKI_DIR}/crypki-bin /usr/bin/
+COPY --from=0 ${CRYPKI_DIR}/gen-cacert /usr/bin/
 COPY ./docker-softhsm/init_hsm.sh /opt/crypki
 COPY ./docker-softhsm/crypki.conf.sample /opt/crypki
 
-RUN mkdir -p /var/log/crypki /opt/crypki \
+RUN mkdir -p /var/log/crypki /opt/crypki /opt/crypki/slot_pubkeys \
 && apt-get update \
-&& apt-get install -y softhsm opensc \
+&& apt-get install -y softhsm opensc openssl \
 && /bin/bash -x /opt/crypki/init_hsm.sh
 
 CMD ["/usr/bin/crypki-bin", "-config", "/opt/crypki/crypki-softhsm.json"]

--- a/docker-softhsm/crypki.conf.sample
+++ b/docker-softhsm/crypki.conf.sample
@@ -29,6 +29,8 @@
         {
             "Identifier": "ssh-user-key",
             "KeyLabel": "user_ssh",
+            "KeyType": 3,
+            "SignatureAlgo": 11,
             "SlotNumber": SLOTNUM_USER_SSH,
             "UserPinPath": "/dev/shm/slot_pwd.txt"
         },

--- a/docker-softhsm/gen-crt.sh
+++ b/docker-softhsm/gen-crt.sh
@@ -25,7 +25,7 @@ openssl \
   -newkey rsa:4096 -nodes \
   -keyout ca.key \
   -x509 -days 36500 -out ca.crt \
-  -subj "/C=US/ST=NRW/L=Earth/O=CompanyName/OU=IT/CN=www.example.com/emailAddress=email@example.com"
+  -subj "/C=US/ST=NRW/L=Earth/O=CompanyName/OU=IT/CN=www.example.com"
 
 # generate server private key
 openssl genrsa -out server.key 4096
@@ -40,7 +40,7 @@ openssl \
 
 # sign server.csr by root CA
 # add SAN `crypki` for docker network access.
-openssl x509 -req -extfile <(printf "subjectAltName=DNS:crypki") -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 36500 -sha256
+openssl x509 -req -extfile <(printf "subjectAltName=DNS:localhost, DNS:crypki") -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 36500 -sha256
 
 
 # for mutual TLS

--- a/docker-softhsm/init_hsm.sh
+++ b/docker-softhsm/init_hsm.sh
@@ -25,15 +25,20 @@ SOPIN=1234
 USERPIN=123456
 
 modulepath="/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"
+slot_pubkeys_path="/opt/crypki/slot_pubkeys"
 
 user_ssh_label="user_ssh"
 host_x509_label="host_x509"
 host_ssh_label="host_ssh"
 sign_blob_label="sign_blob"
-user_ssh_keytype="rsa:4096"
+user_ssh_keytype="EC:prime384v1"
 host_x509_keytype="EC:prime384v1"
 host_ssh_keytype="rsa:4096"
 sign_blob_keytype="rsa:4096"
+user_ssh_cypher_cmd="ec"
+host_x509_cypher_cmd="ec"
+host_ssh_cypher_cmd="rsa"
+sign_blob_cypher_cmd="rsa"
 
 #
 # check for required binaries and libraries
@@ -53,6 +58,11 @@ if [ ! -x "${softhsm}" ]; then
 	error "Can't find softhsm binary in path or /usr/bin/softhsm2-util. Needed to configure the HSM/PKCS#11 device.
 	yum -y install softhsm or apt-get install softhsm # (or local equivalent package)"
 fi
+openssl="${openssl:=/usr/bin/openssl}"
+if [ ! -x "${openssl}" ]; then
+	error "Can't find openssl binary in path or /usr/bin/openssl. Needed to install openssl.
+	yum -y install openssl or apt-get install openssl # (or local equivalent package)"
+fi
 
 set -e # exit if anything at all fails after here
 
@@ -69,6 +79,17 @@ ${p11tool} --module ${modulepath} --pin ${USERPIN} --slot ${user_ssh_slot} --key
 ${p11tool} --module ${modulepath} --pin ${USERPIN} --slot ${host_x509_slot} --keypairgen --label ${host_x509_label} --key-type ${host_x509_keytype} --private
 ${p11tool} --module ${modulepath} --pin ${USERPIN} --slot ${host_ssh_slot} --keypairgen --label ${host_ssh_label} --key-type ${host_ssh_keytype} --private
 ${p11tool} --module ${modulepath} --pin ${USERPIN} --slot ${sign_blob_slot} --keypairgen --label ${sign_blob_label} --key-type ${sign_blob_keytype} --private
+
+# Store the CA public keys of each PKCS11 slot.
+# The public keys are useful to configure CA for PSSHCA deployment.
+${p11tool} --module ${modulepath} -r --type pubkey --slot ${user_ssh_slot} --label ${user_ssh_label} -l --output-file ${slot_pubkeys_path}/${user_ssh_label}_pub.der --pin=${USERPIN}
+${p11tool} --module ${modulepath} -r --type pubkey --slot ${host_x509_slot} --label ${host_x509_label} -l --output-file ${slot_pubkeys_path}/${host_x509_label}_pub.der --pin=${USERPIN}
+${p11tool} --module ${modulepath} -r --type pubkey --slot ${host_ssh_slot} --label ${host_ssh_label} -l --output-file ${slot_pubkeys_path}/${host_ssh_label}_pub.der --pin=${USERPIN}
+${p11tool} --module ${modulepath} -r --type pubkey --slot ${sign_blob_slot} --label ${sign_blob_label} -l --output-file ${slot_pubkeys_path}/${sign_blob_label}_pub.der --pin=${USERPIN}
+openssl ${user_ssh_cypher_cmd} -inform DER -in ${slot_pubkeys_path}/${user_ssh_label}_pub.der -pubin -out ${slot_pubkeys_path}/${user_ssh_label}_pub.pem
+openssl ${host_x509_cypher_cmd} -inform DER -in ${slot_pubkeys_path}/${host_x509_label}_pub.der -pubin -out ${slot_pubkeys_path}/${host_x509_label}_pub.pem
+openssl ${host_ssh_cypher_cmd} -inform DER -in ${slot_pubkeys_path}/${host_ssh_label}_pub.der -pubin -out ${slot_pubkeys_path}/${host_ssh_label}_pub.pem
+openssl ${sign_blob_cypher_cmd} -inform DER -in ${slot_pubkeys_path}/${sign_blob_label}_pub.der -pubin -out ${slot_pubkeys_path}/${sign_blob_label}_pub.pem
 
 CRYPKI_CONFIG=`sed -e "s/SLOTNUM_USER_SSH/${user_ssh_slot}/g; s/SLOTNUM_HOST_X509/${host_x509_slot}/g; s/SLOTNUM_HOST_SSH/${host_ssh_slot}/g; s/SLOTNUM_SIGN_BLOB/${sign_blob_slot}/g" crypki.conf.sample`
 


### PR DESCRIPTION
PR:
* switches ssh-user-cert endpoint to ec-prime384 for `docker-softhsm`
* export signing pubic key to path `slot_pubkeys_path` for users to extract ca keys easily
* compile `gen-cacert` in docker

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
