### PR TITLE
Move signing of data to worker

### DIFF
--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -48,15 +48,6 @@ type Request struct {
 	errChan    chan error     // errChan is channel where the worker sends an error in case it is not able to sign the request
 }
 
-// Response is used to get signed metadata from the worker. It contains the signed data along with the total time
-// taken to retrieve both signer from pool & the signing operation in HSM.
-type Response struct {
-	data     []byte
-	poolTime int64
-	hsmTime  int64
-	err      error
-}
-
 type signerX509 struct {
 	cert             *x509.Certificate
 	identifier       string

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -450,11 +450,7 @@ func TestSignX509ECCert(t *testing.T) {
 		t.Run(label, func(t *testing.T) {
 			signer := initMockSigner(x509.ECDSA, caPriv, caCert, tt.isBadSigner, timeout, 10)
 			var data []byte
-			if label == "x509-ec-ca-cert-no-server" {
-				data, err = signer.SignX509Cert(tt.ctx, nil, tt.cert, tt.identifier, tt.priority)
-			} else {
-				data, err = signer.SignX509Cert(tt.ctx, reqChan, tt.cert, tt.identifier, tt.priority)
-			}
+			data, err = signer.SignX509Cert(tt.ctx, reqChan, tt.cert, tt.identifier, tt.priority)
 			if (err != nil) != tt.expectError {
 				t.Fatalf("%s: got err: %v, expect err: %v", label, err, tt.expectError)
 			}

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -136,6 +136,7 @@ func TestGetSSHCertSigningKey(t *testing.T) {
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	reqChan := make(chan scheduler.Request)
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -287,7 +288,7 @@ func TestGetX509CACert(t *testing.T) {
 		"bad-signer":     {defaultIdentifier, true, false},
 	}
 	reqChan := make(chan scheduler.Request)
-
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -584,6 +585,7 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	reqChan := make(chan scheduler.Request)
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {

--- a/pkcs11/signerpool.go
+++ b/pkcs11/signerpool.go
@@ -53,5 +53,7 @@ func (c *SignerPool) get(ctx context.Context) (signerWithSignAlgorithm, error) {
 }
 
 func (c *SignerPool) put(instance signerWithSignAlgorithm) {
-	c.signers <- instance
+	if instance != nil {
+		c.signers <- instance
+	}
 }

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -37,8 +37,8 @@ type Work struct {
 
 // signerMetadata is an interface for the worker to get the work done.
 type signerMetadata interface {
-	getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error)
-	signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error)
+	getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, doneCh chan bool)
+	signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, doneCh chan bool)
 }
 
 // DoWork performs the work of fetching the signer from the pool and sending it back on the response channel.
@@ -52,17 +52,16 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 	}
 	start := time.Now()
 	signerResp := make(chan sInfo)
-	dataCh := make(chan []byte)
-	errCh := make(chan error)
+	done := make(chan bool)
 
-	reqCtx, cancel := context.WithTimeout(context.Background(), worker.PKCS11Timeout)
-	defer cancel()
+	requestCtx, cancel := context.WithTimeout(context.Background(), worker.PKCS11Timeout)
 	var (
 		ht, pt         int64
 		pStart, hStart time.Time
 	)
 
 	defer func() {
+		cancel()
 		tt := time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds()
 		log.Printf("m=%s: ht=%d, tt=%d, pt=%d", w.work.method, ht, tt, pt)
 	}()
@@ -77,18 +76,16 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 		case signerResp <- sInfo{signer, err}:
 			// case when we fetched signer from the pool.
 		}
-	}(reqCtx)
+	}(requestCtx)
 
 	for {
 		select {
 		case <-workerCtx.Done():
 			// Case 1: Worker stopped or cancelled request.
 			// The client is still waiting for a response, so return on error channel.
-			worker.TotalTimeout.Inc()
-			cancel()
 			w.work.errChan <- errors.New("worker cancelled request")
 			return
-		case <-reqCtx.Done():
+		case <-requestCtx.Done():
 			// Case 2: HSM/PKCS11 request timed out.
 			// The client is still waiting for a response in this case, so return on error channel.
 			worker.TotalTimeout.Inc()
@@ -98,7 +95,6 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 			// Case 3: Client cancelled the request.
 			// In this case we no longer need to process the signing request & we should clean up signer if assigned & return.
 			worker.TotalTimeout.Inc()
-			cancel()
 			return
 		case sResp := <-signerResp:
 			pt = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
@@ -114,30 +110,45 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 			hStart = time.Now()
 			switch w.work.method {
 			case "GetSSHCertSigningKey", "GetX509CACert", "GetBlobSigningPublicKey":
-				go w.work.signerData.getData(reqCtx, sResp.signer, w.work.pool, dataCh, errCh)
+				go w.work.signerData.getData(requestCtx, sResp.signer, w.work.pool, w.work.respChan, w.work.errChan, done)
 			case "SignSSHCert", "SignX509Cert", "SignBlob":
-				go w.work.signerData.signData(reqCtx, sResp.signer, w.work.pool, dataCh, errCh)
+				go w.work.signerData.signData(requestCtx, sResp.signer, w.work.pool, w.work.respChan, w.work.errChan, done)
 			}
-		case resp := <-dataCh:
+		case <-done:
 			ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 			// Case 5: HSM has completed the signing operation & we need to send response back to client.
-			w.work.respChan <- resp
-			return
-		case err := <-errCh:
-			w.work.errChan <- err
 			return
 		}
 	}
 }
 
 // getData gets X509 CA certificate.
-func (s *signerX509) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-
+func (s *signerX509) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	defer pool.put(signer)
+	certBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: s.x509CACert.Raw,
+	})
+	select {
+	case <-ctx.Done():
+	case data <- certBytes:
+		done <- true
+	}
 }
 
 // signData signs X509 certificate by using the signer fetched from the pool.
-func (s *signerX509) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-	defer pool.put(signer)
+func (s *signerX509) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	var e error
+	defer func() {
+		if e != nil {
+			select {
+			case <-ctx.Done():
+			case errCh <- e:
+				done <- true
+			}
+		}
+		pool.put(signer)
+	}()
 	// Validate the cert request to ensure it matches the keyType and also the HSM supports the signature algo.
 	if val := isValidCertRequest(s.cert, signer.signAlgorithm()); !val {
 		log.Printf("signX509cert: cn=%q unsupported-sa=%q supported-sa=%d",
@@ -151,77 +162,130 @@ func (s *signerX509) signData(ctx context.Context, signer signerWithSignAlgorith
 
 	signedCert, err := x509.CreateCertificate(rand.Reader, s.cert, s.x509CACert, s.cert.PublicKey, signer)
 	if err != nil {
-		errCh <- err
+		e = err
 		return
 	}
+	signedData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert})
 	select {
 	case <-ctx.Done():
-	case data <- pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert}):
+	case data <- signedData:
+		done <- true
 	}
 }
 
 // getData gets SSH certificate signing key by using the signer fetched from the pool.
-func (s *signerSSH) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-	defer pool.put(signer)
+func (s *signerSSH) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	var e error
+	defer func() {
+		if e != nil {
+			select {
+			case <-ctx.Done():
+			case errCh <- e:
+				done <- true
+			}
+		}
+		pool.put(signer)
+	}()
 
 	sshSigner, err := ssh.NewSignerFromSigner(signer)
 	if err != nil {
-		errCh <- fmt.Errorf("failed to create sshSigner: %v", err)
+		e = fmt.Errorf("failed to create sshSigner: %v", err)
 		return
 	}
-	data <- ssh.MarshalAuthorizedKey(sshSigner.PublicKey())
+	select {
+	case <-ctx.Done():
+	case data <- ssh.MarshalAuthorizedKey(sshSigner.PublicKey()):
+		done <- true
+	}
 }
 
 // signData signs SSH certificate by using the signer fetched from the pool.
-func (s *signerSSH) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-	defer pool.put(signer)
+func (s *signerSSH) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	var e error
+	defer func() {
+		if e != nil {
+			select {
+			case <-ctx.Done():
+			case errCh <- e:
+				done <- true
+			}
+		}
+		pool.put(signer)
+	}()
 	if s.cert == nil {
-		errCh <- errors.New("signSSHCert: cannot sign empty cert")
+		e = errors.New("signSSHCert: cannot sign empty cert")
 		return
 	}
 
 	sshSigner, err := newAlgorithmSignerFromSigner(signer, signer.publicKeyAlgorithm(), signer.signAlgorithm())
 	if err != nil {
-		errCh <- fmt.Errorf("failed to new ssh signer from signer, error :%v", err)
+		e = fmt.Errorf("failed to new ssh signer from signer, error :%v", err)
 		return
 	}
 	if err := s.cert.SignCert(rand.Reader, sshSigner); err != nil {
-		errCh <- err
+		e = err
 		return
 	}
+	signedData := bytes.TrimSpace(ssh.MarshalAuthorizedKey(s.cert))
 	select {
 	case <-ctx.Done():
-	case data <- bytes.TrimSpace(ssh.MarshalAuthorizedKey(s.cert)):
+	case data <- signedData:
+		done <- true
 	}
 }
 
 // getData gets blob signing public key by using the signer fetched from the pool.
-func (s *signerBlob) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-	defer pool.put(signer)
+func (s *signerBlob) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	var e error
+	defer func() {
+		if e != nil {
+			select {
+			case <-ctx.Done():
+			case errCh <- e:
+				done <- true
+			}
+		}
+		pool.put(signer)
+	}()
 	pk, err := x509.MarshalPKIXPublicKey(signer.Public())
 	if err != nil {
-		errCh <- err
+		e = err
 		return
 	}
-	b := &pem.Block{Type: "PUBLIC KEY", Bytes: pk}
-	data <- pem.EncodeToMemory(b)
+	signedData := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pk})
+	select {
+	case <-ctx.Done():
+	case data <- signedData:
+		done <- true
+	}
 }
 
 // signData signs blob data by using the signer fetched from the pool.
-func (s *signerBlob) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
-	defer pool.put(signer)
+func (s *signerBlob) signData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error, done chan bool) {
+	var e error
+	defer func() {
+		if e != nil {
+			select {
+			case <-ctx.Done():
+			case errCh <- e:
+				done <- true
+			}
+		}
+		pool.put(signer)
+	}()
 	if s.digest == nil {
-		errCh <- fmt.Errorf("signBlob: cannot sign empty digest")
+		e = fmt.Errorf("signBlob: cannot sign empty digest")
 		return
 	}
 
 	signature, err := signer.Sign(rand.Reader, s.digest, s.opts)
 	if err != nil {
-		errCh <- err
+		e = err
 		return
 	}
 	select {
 	case <-ctx.Done():
 	case data <- signature:
+		done <- true
 	}
 }

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -130,13 +130,6 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 	}
 }
 
-// sendResponse sends the response on the respChan if the channel is not yet closed by the client.
-func (w *Work) sendResponse(resp Response) {
-
-	// case when client is waiting for a response from worker.
-	// close(w.work.respChan)
-}
-
 // getData gets X509 CA certificate.
 func (s *signerX509) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
 
@@ -177,7 +170,6 @@ func (s *signerSSH) getData(ctx context.Context, signer signerWithSignAlgorithm,
 		return
 	}
 	data <- ssh.MarshalAuthorizedKey(sshSigner.PublicKey())
-	return
 }
 
 // signData signs SSH certificate by using the signer fetched from the pool.
@@ -213,7 +205,6 @@ func (s *signerBlob) getData(ctx context.Context, signer signerWithSignAlgorithm
 	}
 	b := &pem.Block{Type: "PUBLIC KEY", Bytes: pk}
 	data <- pem.EncodeToMemory(b)
-	return
 }
 
 // signData signs blob data by using the signer fetched from the pool.

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -47,6 +47,7 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 
 	signerRespCh := make(chan signerResponse)
 	reqCtx, cancel := context.WithTimeout(context.Background(), worker.PKCS11Timeout)
+	defer cancel()
 	var pt int64
 	pStart := time.Now()
 	go func(ctx context.Context) {
@@ -86,7 +87,6 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 		// Case 3: Client cancelled the request, either due to client time out or some other reason.
 		// In this case we no longer need to process the signing request & we should clean up signer if assigned & return.
 		worker.TotalTimeout.Inc()
-		cancel()
 		return
 	case resp := <-signerRespCh:
 		// Case 4: Received signer from signer pool. We need to sign the request & send the response. Before we send the

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -95,7 +95,7 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 			worker.TotalTimeout.Inc()
 			cancel()
 			return
-		case sResp, _ := <-signerResp:
+		case sResp := <-signerResp:
 			// Case 4: Received signer from signer pool. We need to sign the request & send the response. Before we send the
 			// response, we should ensure client is still waiting for the response.
 			poolTime = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
@@ -151,10 +151,8 @@ func (s *signerX509) signData(ctx context.Context, signer signerWithSignAlgorith
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert}), hsmTime: ht}:
 	}
-	return
 }
 
 // signData signs SSH certificate by using the signer fetched from the pool.
@@ -181,10 +179,8 @@ func (s *signerSSH) signData(ctx context.Context, signer signerWithSignAlgorithm
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: bytes.TrimSpace(ssh.MarshalAuthorizedKey(s.cert)), hsmTime: ht}:
 	}
-	return
 }
 
 // signData signs blob data by using the signer fetched from the pool.
@@ -207,8 +203,6 @@ func (s *signerBlob) signData(ctx context.Context, signer signerWithSignAlgorith
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: signature, hsmTime: ht}:
 	}
-	return
 }


### PR DESCRIPTION
This PR contains the foll. changes:
1. Move the signing data logic to worker instead of client.
2. Handle cases when pkcs11 timeout or client cancel request.
3. Introduce HSM timeout to have an upper bound on hsm signing request
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

![Crypki Priority Based - Sequence Diagram](https://user-images.githubusercontent.com/6836802/164085960-bc1489d4-6382-44b6-903e-01affa8768de.png)


