### PR TITLE
add sign-x509cert

### DIFF
--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -1,5 +1,17 @@
-// Copyright 2019, Oath Inc.
-// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/sign-x509cert/main.go
+++ b/cmd/sign-x509cert/main.go
@@ -1,0 +1,162 @@
+// Copyright 2021 Yahoo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/theparanoids/crypki"
+	"github.com/theparanoids/crypki/config"
+	"github.com/theparanoids/crypki/pkcs11"
+	"github.com/theparanoids/crypki/proto"
+)
+
+const defaultRequestTimeout = 10
+
+var cfg string
+var validityDays uint64
+var csrPath string
+var caPath string
+var certOutPath string
+
+func parseFlags() {
+	flag.StringVar(&cfg, "config", "", "CA key configuration file")
+	flag.Uint64Var(&validityDays, "days", 730, "validity period in days")
+	flag.StringVar(&caPath, "cacert", "", "path to CA cert")
+	flag.StringVar(&csrPath, "in", "", "CSR path")
+	flag.StringVar(&certOutPath, "out", "", "the output path of signed cert (The same dir path of the given csr will be applied if this var is not specified.)")
+	flag.Parse()
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	if cfg == "" {
+		log.Fatal("no CA key configuration file specified")
+	}
+
+	if caPath == "" {
+		log.Fatal("no ca cert path specified")
+	}
+
+	if csrPath == "" {
+		log.Fatal("no CSR path specified")
+	}
+
+	if certOutPath == "" {
+		certOutPath = fmt.Sprintf("%s.%s", strings.TrimSuffix(csrPath, filepath.Ext(csrPath)), "crt")
+	}
+}
+
+func constructUnsignedX509Cert() *x509.Certificate {
+	csrData, err := os.ReadFile(csrPath)
+	if err != nil {
+		log.Fatalf("failed to read csrPath file: %v", err)
+	}
+
+	csrBlock, _ := pem.Decode(csrData)
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		log.Fatalf("failed to parse cert request: %v", err)
+	}
+
+	return &x509.Certificate{
+		Subject:               csr.Subject,
+		SerialNumber:          newSerial(),
+		PublicKeyAlgorithm:    csr.PublicKeyAlgorithm,
+		PublicKey:             csr.PublicKey,
+		SignatureAlgorithm:    csr.SignatureAlgorithm,
+		NotBefore:             time.Now().Add(-time.Hour), // backdate to address possible clock drift
+		NotAfter:              time.Now().Add(time.Hour * 24 * time.Duration(validityDays)),
+		DNSNames:              csr.DNSNames,
+		IPAddresses:           csr.IPAddresses,
+		EmailAddresses:        csr.EmailAddresses,
+		URIs:                  csr.URIs,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+}
+
+func newSerial() *big.Int {
+	const (
+		minBits   = 64  // https://cabforum.org/2016/03/31/ballot-164/
+		maxBits   = 160 // https://tools.ietf.org/html/rfc5280#section-4.1.2.2
+		tolerance = 2
+	)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), maxBits-minBits-tolerance)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	return serialNumber.Lsh(serialNumber, minBits)
+}
+
+func main() {
+	parseFlags()
+
+	cfgData, err := os.ReadFile(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cc := &crypki.CAConfig{}
+	if err := json.Unmarshal(cfgData, cc); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// x509 requires CA certs.
+	requireX509CACert := map[string]bool{
+		cc.Identifier: true,
+	}
+
+	signer, err := pkcs11.NewCertSign(ctx, cc.PKCS11ModulePath, []config.KeyConfig{{
+		Identifier:             cc.Identifier,
+		SlotNumber:             uint(cc.SlotNumber),
+		UserPinPath:            cc.UserPinPath,
+		KeyLabel:               cc.KeyLabel,
+		KeyType:                x509.PublicKeyAlgorithm(cc.KeyType),
+		SignatureAlgo:          x509.SignatureAlgorithm(cc.SignatureAlgo),
+		SessionPoolSize:        2,
+		X509CACertLocation:     caPath,
+		CreateCACertIfNotExist: false,
+	}}, requireX509CACert, "", nil, defaultRequestTimeout) // Hostname and ips should not be needed as CreateCACertIfNotExist is set to be false.
+
+	if err != nil {
+		log.Fatalf("unable to initialize cert signer: %v", err)
+	}
+
+	unsignedCert := constructUnsignedX509Cert()
+
+	data, err := signer.SignX509Cert(ctx, nil, unsignedCert, cc.Identifier, proto.Priority_Unspecified_priority)
+	if err != nil {
+		log.Fatalf("falied to sign x509 cert: %v", err)
+	}
+
+	if err := ioutil.WriteFile(certOutPath, data, 0444); err != nil {
+		log.Printf("the newly signed cert has been generated, but unable to write to file %s: %v", certOutPath, err)
+	} else {
+		log.Printf("the newly signed x509 cert has been written to %s", certOutPath)
+	}
+}


### PR DESCRIPTION
This PR adds sign-x509 cert standalone sign once support.

This can be used for signing a certificate signing request for server/client TLS certs.

eg: 
```
$ cat>tls_server_csr.conf<<EOF
[ req ]
distinguished_name = req_distinguished_name
req_extensions     = req_ext
prompt = no
[ req_distinguished_name ]
C="US"
ST=CA
L=Sunnyvale
O=Yahoo
OU=Engineering
CN=test.yahoo.com
[ req_ext ]
subjectAltName=$(echo "DNS:${hosts}" | sed -e "s/,/,DNS:/g")
EOF

$ openssl genrsa -out tls_server.key 4096

$ openssl req -sha256 -new -config tls_server_csr.conf -key tls_server.key -nodes -out tls_server.csr

$ sudo ./sign-x509cert -config ca_config.cfg -days 730 -cacert ./tls_signing_ca.crt -in tls_server.csr
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
