### PR TITLE
Add request chan to Get request for fetching certificates

### DIFF
--- a/api/blob.go
+++ b/api/blob.go
@@ -63,7 +63,7 @@ func (s *SigningService) GetBlobSigningKey(ctx context.Context, keyMeta *proto.K
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
 
-	key, err := s.GetBlobSigningPublicKey(ctx, keyMeta.Identifier)
+	key, err := s.GetBlobSigningPublicKey(ctx, s.RequestChan[config.BlobEndpoint], keyMeta.Identifier)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		return nil, status.Error(codes.Internal, "Internal server error")

--- a/api/sign_test.go
+++ b/api/sign_test.go
@@ -91,19 +91,19 @@ type mockSigningServiceParam struct {
 type mockBadCertSign struct {
 }
 
-func (mbcs *mockBadCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetSSHCertSigningKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetX509CACert(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
-func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mbcs *mockBadCertSign) GetBlobSigningPublicKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return nil, errors.New("bad message")
 }
 func (mbcs *mockBadCertSign) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {
@@ -113,19 +113,19 @@ func (mbcs *mockBadCertSign) SignBlob(ctx context.Context, reqChan chan schedule
 type mockGoodCertSign struct {
 }
 
-func (mgcs *mockGoodCertSign) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetSSHCertSigningKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return []byte("good ssh signing key"), nil
 }
 func (mgcs *mockGoodCertSign) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return []byte("good ssh cert"), nil
 }
-func (mgcs *mockGoodCertSign) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetX509CACert(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return []byte("good x509 ca cert"), nil
 }
 func (mgcs *mockGoodCertSign) SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error) {
 	return []byte("good x509 cert"), nil
 }
-func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (mgcs *mockGoodCertSign) GetBlobSigningPublicKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	return []byte("good blob signing key"), nil
 }
 func (mgcs *mockGoodCertSign) SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error) {

--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -73,7 +73,7 @@ func (s *SigningService) GetHostSSHCertificateSigningKey(ctx context.Context, ke
 	}
 	respCh := make(chan resp)
 	go func() {
-		key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
+		key, err := s.GetSSHCertSigningKey(ctx, s.RequestChan[config.SSHHostCertEndpoint], keyMeta.Identifier)
 		respCh <- resp{key, err}
 	}()
 

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -73,7 +73,7 @@ func (s *SigningService) GetUserSSHCertificateSigningKey(ctx context.Context, ke
 	}
 	respCh := make(chan resp)
 	go func() {
-		key, err := s.GetSSHCertSigningKey(ctx, keyMeta.Identifier)
+		key, err := s.GetSSHCertSigningKey(ctx, s.RequestChan[config.SSHUserCertEndpoint], keyMeta.Identifier)
 		respCh <- resp{key, err}
 	}()
 

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -72,7 +72,7 @@ func (s *SigningService) GetX509CACertificate(ctx context.Context, keyMeta *prot
 	}
 	respCh := make(chan resp)
 	go func() {
-		cert, err := s.GetX509CACert(ctx, keyMeta.Identifier)
+		cert, err := s.GetX509CACert(ctx, s.RequestChan[config.X509CertEndpoint], keyMeta.Identifier)
 		respCh <- resp{cert, err}
 	}()
 

--- a/crypki.go
+++ b/crypki.go
@@ -39,15 +39,15 @@ const (
 // CertSign interface contains methods related to signing certificates.
 type CertSign interface {
 	// GetSSHCertSigningKey returns the SSH signing key of the specified key.
-	GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error)
+	GetSSHCertSigningKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error)
 	// SignSSHCert returns an SSH cert signed by the specified key.
 	SignSSHCert(ctx context.Context, reqChan chan scheduler.Request, cert *ssh.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error)
 	// GetX509CACert returns the X509 CA cert of the specified key.
-	GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error)
+	GetX509CACert(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error)
 	// SignX509Cert returns an x509 cert signed by the specified key.
 	SignX509Cert(ctx context.Context, reqChan chan scheduler.Request, cert *x509.Certificate, keyIdentifier string, priority proto.Priority) ([]byte, error)
 	// GetBlobSigningPublicKey returns the public signing key of the specified key that signs the user's data.
-	GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error)
+	GetBlobSigningPublicKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error)
 	// SignBlob returns a signature signed by the specified key.
 	SignBlob(ctx context.Context, reqChan chan scheduler.Request, digest []byte, opts crypto.SignerOpts, keyIdentifier string, priority proto.Priority) ([]byte, error)
 }

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -158,7 +158,7 @@ func NewCertSign(ctx context.Context, pkcs11ModulePath string, keys []config.Key
 	return s, nil
 }
 
-func (s *signer) GetSSHCertSigningKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (s *signer) GetSSHCertSigningKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)
@@ -215,7 +215,7 @@ func (s *signer) SignSSHCert(ctx context.Context, reqChan chan scheduler.Request
 	return bytes.TrimSpace(ssh.MarshalAuthorizedKey(cert)), nil
 }
 
-func (s *signer) GetX509CACert(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (s *signer) GetX509CACert(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	cert, ok := s.x509CACerts[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unable to find CA cert for key identifier %q", keyIdentifier)
@@ -271,7 +271,7 @@ func (s *signer) SignX509Cert(ctx context.Context, reqChan chan scheduler.Reques
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert}), nil
 }
 
-func (s *signer) GetBlobSigningPublicKey(ctx context.Context, keyIdentifier string) ([]byte, error) {
+func (s *signer) GetBlobSigningPublicKey(ctx context.Context, reqChan chan scheduler.Request, keyIdentifier string) ([]byte, error) {
 	pool, ok := s.sPool[keyIdentifier]
 	if !ok {
 		return nil, fmt.Errorf("unknown key identifier %q", keyIdentifier)

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -135,6 +135,7 @@ func TestGetSSHCertSigningKey(t *testing.T) {
 		"bad-signer":          {ctx, defaultIdentifier, true, true},
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
+	reqChan := make(chan scheduler.Request)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -143,7 +144,7 @@ func TestGetSSHCertSigningKey(t *testing.T) {
 				t.Fatalf("unable to create CA keys and certificate: %v", err)
 			}
 			signer := initMockSigner(x509.RSA, caPriv, caCert, tt.isBadSigner, timeout, 10)
-			_, err = signer.GetSSHCertSigningKey(tt.ctx, tt.identifier)
+			_, err = signer.GetSSHCertSigningKey(tt.ctx, reqChan, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -285,6 +286,8 @@ func TestGetX509CACert(t *testing.T) {
 		"bad-identifier": {badIdentifier, false, true},
 		"bad-signer":     {defaultIdentifier, true, false},
 	}
+	reqChan := make(chan scheduler.Request)
+
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -293,7 +296,7 @@ func TestGetX509CACert(t *testing.T) {
 				t.Fatalf("unable to create CA keys and certificate: %v", err)
 			}
 			signer := initMockSigner(x509.RSA, caPriv, caCert, tt.isBadSigner, timeout, 10)
-			_, err = signer.GetX509CACert(ctx, tt.identifier)
+			_, err = signer.GetX509CACert(ctx, reqChan, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}
@@ -584,6 +587,7 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 		"bad-signer":          {ctx, defaultIdentifier, true, true},
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
+	reqChan := make(chan scheduler.Request)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -592,7 +596,7 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 				t.Fatalf("unable to create CA keys and certificate: %v", err)
 			}
 			signer := initMockSigner(x509.RSA, caPriv, caCert, tt.isBadSigner, timeout, 10)
-			_, err = signer.GetBlobSigningPublicKey(tt.ctx, tt.identifier)
+			_, err = signer.GetBlobSigningPublicKey(tt.ctx, reqChan, tt.identifier)
 			if err != nil != tt.expectError {
 				t.Fatalf("got err: %v, expect err: %v", err, tt.expectError)
 			}


### PR DESCRIPTION
GET operation also requires signer for getting key info, we need to start supporting any get operation via worker instead of fetching the signer from pool directly. This PR is to lay a framework for eventually sending all get requests to worker.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
