### PR TITLE
Improve: Move signing of data to worker

### DIFF
--- a/api/sshhost.go
+++ b/api/sshhost.go
@@ -127,7 +127,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 	defer cancel() // Cancel ctx as soon as PostHostSSHCertificate returns
 
 	maxValidity := s.MaxValidity[config.SSHHostCertEndpoint]
-	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {
+	if err = checkValidity(request.GetValidity(), maxValidity); err != nil {
 		statusCode = http.StatusBadRequest
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
@@ -169,6 +169,7 @@ func (s *SigningService) PostHostSSHCertificate(ctx context.Context, request *pr
 	case response := <-respCh:
 		if response.err != nil {
 			statusCode = http.StatusInternalServerError
+			err = fmt.Errorf("internal server error %v", response.err)
 			return nil, status.Error(codes.Internal, "Internal server error")
 		}
 		return &proto.SSHKey{Key: string(response.data)}, nil

--- a/api/sshuser.go
+++ b/api/sshuser.go
@@ -127,7 +127,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 	defer cancel() // Cancel ctx as soon as PostUserSSHCertificate returns
 
 	maxValidity := s.MaxValidity[config.SSHUserCertEndpoint]
-	if err := checkValidity(request.GetValidity(), maxValidity); err != nil {
+	if err = checkValidity(request.GetValidity(), maxValidity); err != nil {
 		statusCode = http.StatusBadRequest
 		return nil, status.Errorf(codes.InvalidArgument, "Bad request: %v", err)
 	}
@@ -169,6 +169,7 @@ func (s *SigningService) PostUserSSHCertificate(ctx context.Context, request *pr
 	case response := <-respCh:
 		if response.err != nil {
 			statusCode = http.StatusInternalServerError
+			err = fmt.Errorf("internal server error %v", response.err)
 			return nil, status.Error(codes.Internal, "Internal server error")
 		}
 		return &proto.SSHKey{Key: string(response.data)}, nil

--- a/api/x509cert.go
+++ b/api/x509cert.go
@@ -115,7 +115,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	}
 
 	// Create a context with server side timeout.
-	reqCtx, cancel := context.WithTimeout(ctx, time.Duration(s.RequestTimeout)*time.Second)
+	reqCtx, cancel := context.WithTimeout(ctx, 200 * time.Millisecond)
 	defer cancel() // Cancel ctx as soon as PostX509Certificate returns
 
 	maxValidity := s.MaxValidity[config.X509CertEndpoint]
@@ -160,6 +160,7 @@ func (s *SigningService) PostX509Certificate(ctx context.Context, request *proto
 	case response := <-respCh:
 		if response.err != nil {
 			statusCode = http.StatusInternalServerError
+			err = fmt.Errorf("internal server error %v", response.err)
 			return nil, status.Error(codes.Internal, "Internal server error")
 		}
 		return &proto.X509Certificate{Cert: string(response.cert)}, nil

--- a/pkcs11/signer.go
+++ b/pkcs11/signer.go
@@ -48,15 +48,6 @@ type Request struct {
 	errChan    chan error     // errChan is channel where the worker sends an error in case it is not able to sign the request
 }
 
-// Response is used to get signed metadata from the worker. It contains the signed data along with the total time
-// taken to retrieve both signer from pool & the signing operation in HSM.
-type Response struct {
-	data     []byte
-	poolTime int64
-	hsmTime  int64
-	err      error
-}
-
 type signerX509 struct {
 	cert             *x509.Certificate
 	identifier       string

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -450,11 +450,7 @@ func TestSignX509ECCert(t *testing.T) {
 		t.Run(label, func(t *testing.T) {
 			signer := initMockSigner(x509.ECDSA, caPriv, caCert, tt.isBadSigner, timeout, 10)
 			var data []byte
-			if label == "x509-ec-ca-cert-no-server" {
-				data, err = signer.SignX509Cert(tt.ctx, nil, tt.cert, tt.identifier, tt.priority)
-			} else {
-				data, err = signer.SignX509Cert(tt.ctx, reqChan, tt.cert, tt.identifier, tt.priority)
-			}
+			data, err = signer.SignX509Cert(tt.ctx, reqChan, tt.cert, tt.identifier, tt.priority)
 			if (err != nil) != tt.expectError {
 				t.Fatalf("%s: got err: %v, expect err: %v", label, err, tt.expectError)
 			}

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -340,7 +340,7 @@ func TestSignX509RSACert(t *testing.T) {
 	cp := x509.NewCertPool()
 	cp.AddCert(caCert)
 
-	ctx, cnc := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cnc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cnc()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkcs11/signer_test.go
+++ b/pkcs11/signer_test.go
@@ -136,6 +136,7 @@ func TestGetSSHCertSigningKey(t *testing.T) {
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	reqChan := make(chan scheduler.Request)
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -287,7 +288,7 @@ func TestGetX509CACert(t *testing.T) {
 		"bad-signer":     {defaultIdentifier, true, false},
 	}
 	reqChan := make(chan scheduler.Request)
-
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {
@@ -584,6 +585,7 @@ func TestGetBlobSigningPublicKey(t *testing.T) {
 		"bad-request-timeout": {timeoutCtx, defaultIdentifier, false, true},
 	}
 	reqChan := make(chan scheduler.Request)
+	go dummyScheduler(ctx, reqChan)
 	for label, tt := range testcases {
 		label, tt := label, tt
 		t.Run(label, func(t *testing.T) {

--- a/pkcs11/signerpool.go
+++ b/pkcs11/signerpool.go
@@ -53,5 +53,7 @@ func (c *SignerPool) get(ctx context.Context) (signerWithSignAlgorithm, error) {
 }
 
 func (c *SignerPool) put(instance signerWithSignAlgorithm) {
-	c.signers <- instance
+	if instance != nil {
+		c.signers <- instance
+	}
 }

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -130,13 +130,6 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 	}
 }
 
-// sendResponse sends the response on the respChan if the channel is not yet closed by the client.
-func (w *Work) sendResponse(resp Response) {
-
-	// case when client is waiting for a response from worker.
-	// close(w.work.respChan)
-}
-
 // getData gets X509 CA certificate.
 func (s *signerX509) getData(ctx context.Context, signer signerWithSignAlgorithm, pool sPool, data chan []byte, errCh chan error) {
 
@@ -177,7 +170,6 @@ func (s *signerSSH) getData(ctx context.Context, signer signerWithSignAlgorithm,
 		return
 	}
 	data <- ssh.MarshalAuthorizedKey(sshSigner.PublicKey())
-	return
 }
 
 // signData signs SSH certificate by using the signer fetched from the pool.
@@ -213,7 +205,6 @@ func (s *signerBlob) getData(ctx context.Context, signer signerWithSignAlgorithm
 	}
 	b := &pem.Block{Type: "PUBLIC KEY", Bytes: pk}
 	data <- pem.EncodeToMemory(b)
-	return
 }
 
 // signData signs blob data by using the signer fetched from the pool.

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -47,6 +47,7 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 
 	signerRespCh := make(chan signerResponse)
 	reqCtx, cancel := context.WithTimeout(context.Background(), worker.PKCS11Timeout)
+	defer cancel()
 	var pt int64
 	pStart := time.Now()
 	go func(ctx context.Context) {
@@ -86,7 +87,6 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 		// Case 3: Client cancelled the request, either due to client time out or some other reason.
 		// In this case we no longer need to process the signing request & we should clean up signer if assigned & return.
 		worker.TotalTimeout.Inc()
-		cancel()
 		return
 	case resp := <-signerRespCh:
 		// Case 4: Received signer from signer pool. We need to sign the request & send the response. Before we send the

--- a/pkcs11/work.go
+++ b/pkcs11/work.go
@@ -95,7 +95,7 @@ func (w *Work) DoWork(workerCtx context.Context, worker *scheduler.Worker) {
 			worker.TotalTimeout.Inc()
 			cancel()
 			return
-		case sResp, _ := <-signerResp:
+		case sResp := <-signerResp:
 			// Case 4: Received signer from signer pool. We need to sign the request & send the response. Before we send the
 			// response, we should ensure client is still waiting for the response.
 			poolTime = time.Since(pStart).Nanoseconds() / time.Microsecond.Nanoseconds()
@@ -151,10 +151,8 @@ func (s *signerX509) signData(ctx context.Context, signer signerWithSignAlgorith
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: signedCert}), hsmTime: ht}:
 	}
-	return
 }
 
 // signData signs SSH certificate by using the signer fetched from the pool.
@@ -181,10 +179,8 @@ func (s *signerSSH) signData(ctx context.Context, signer signerWithSignAlgorithm
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: bytes.TrimSpace(ssh.MarshalAuthorizedKey(s.cert)), hsmTime: ht}:
 	}
-	return
 }
 
 // signData signs blob data by using the signer fetched from the pool.
@@ -207,8 +203,6 @@ func (s *signerBlob) signData(ctx context.Context, signer signerWithSignAlgorith
 	ht = time.Since(hStart).Nanoseconds() / time.Microsecond.Nanoseconds()
 	select {
 	case <-ctx.Done():
-		return
 	case signedDataCh <- Response{data: signature, hsmTime: ht}:
 	}
-	return
 }


### PR DESCRIPTION
PR passes signer's context to worker by schedule reqeust.

It intends to fix the race condition issue mentioned in: https://github.com/theparanoids/crypki/pull/168/files#r846150870

--
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
