### PR TITLE
cacert san field changes

### DIFF
--- a/cmd/gen-cacert/main.go
+++ b/cmd/gen-cacert/main.go
@@ -108,8 +108,6 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-	} else {
-		ips = nil
 	}
 
 	var uris []*url.URL
@@ -119,8 +117,6 @@ func main() {
 			log.Fatal(err)
 		}
 		uris = []*url.URL{parsedUri}
-	} else {
-		uris = nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/sign-x509cert/main.go
+++ b/cmd/sign-x509cert/main.go
@@ -143,7 +143,7 @@ func main() {
 		SessionPoolSize:        2,
 		X509CACertLocation:     caPath,
 		CreateCACertIfNotExist: false,
-	}}, requireX509CACert, "", nil, config.DefaultPKCS11Timeout) // Hostname and ips should not be needed as CreateCACertIfNotExist is set to be false.
+	}}, requireX509CACert, "", nil, nil, config.DefaultPKCS11Timeout) // Hostname and ips should not be needed as CreateCACertIfNotExist is set to be false.
 
 	if err != nil {
 		log.Fatalf("unable to initialize cert signer: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -170,7 +170,7 @@ func Main() {
 		log.Fatal(err)
 	}
 
-	signer, err := pkcs11.NewCertSign(ctx, cfg.ModulePath, cfg.Keys, keyUsages[config.X509CertEndpoint], hostname, ips, cfg.PKCS11RequestTimeout)
+	signer, err := pkcs11.NewCertSign(ctx, cfg.ModulePath, cfg.Keys, keyUsages[config.X509CertEndpoint], hostname, ips, nil, cfg.PKCS11RequestTimeout)
 	if err != nil {
 		log.Fatalf("unable to initialize cert signer: %v", err)
 	}


### PR DESCRIPTION
typically Root CA certificates do not include IP addresses nor hostnames. So the PR introduces two command line options to skip the inclusion of hostname and IP addresses.

Most services are now utilizing spiffe URIs in server and root certificates. There is new -uri option for the gen-cacert utility that the admin can include a spiffe uri that will be included in the SAN field in the root ca certificate.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
