### PR TITLE
remove panic calls from rsa/ecdsa public key methods

### DIFF
--- a/pkcs11/rsa.go
+++ b/pkcs11/rsa.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"errors"
+	"log"
 	"math/big"
 
 	p11 "github.com/miekg/pkcs11"
@@ -38,7 +39,8 @@ func publicRSA(s *p11Signer) crypto.PublicKey {
 	}
 	attr, err := s.context.GetAttributeValue(s.session, s.publicKey, attrTemplate)
 	if err != nil {
-		panic("Error returning public key: " + err.Error())
+		log.Printf("Error returning public key: %v\n", err)
+		return nil
 	}
 	gotMod, gotExp := false, false
 	rsapubkey := new(rsa.PublicKey)
@@ -53,7 +55,8 @@ func publicRSA(s *p11Signer) crypto.PublicKey {
 		}
 	}
 	if !gotExp || !gotMod {
-		panic("unable to retrieve modulus and/or exponent")
+		log.Println("unable to retrieve modulus and/or exponent")
+		return nil
 	}
 	return rsapubkey
 }


### PR DESCRIPTION
both rsa and ecdsa support PublicKey access calls generate panics whenever pkcs11 call to HSM returns any type of error. This is bad since crypki is handling large number of requests and a panic call fails all those active requests. furthermore, all the instances pretty much get killed at the same time and we have a complete outage until systems restarts all instances. the process should not call panic and instead just return nil. all the std go library x.509 cert calls correctly handle when nil is passed for the public key and return an error.

this is particularly a major issue in AWS, where AWS periodically recycles the HSMs. Typically we've seen AWS recycle at least one of the HSMs in each of our clusters every week resulting a brief 5-10 min outage until all the instances are restarted and put back into rotation (sometimes health checks determine the instance state as bad so the instances is killed and restarted).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
