### PR TITLE
Update install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prerequisites:
 Run:
 
 ```sh
-go get github.com/theparanoids/crypki
+go install github.com/theparanoids/crypki/cmd/crypki@latest
 ```
 
 ## Usage 


### PR DESCRIPTION
Use `go install` instead of the legacy `go get`.  Since we say that the Go version must be `>= 1.18`, `go install` will work and `go get` - won't.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
