### PR TITLE
use digest instead of tag when invoking cosign sign

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ docker_signs:
 - cmd: cosign
   args:
   - 'sign'
-  - '${artifact}'
+  - '${artifact}@${digest}'
   artifacts: all
   output: true
 


### PR DESCRIPTION
To avoid this warning - 
```
WARNING: Image reference ghcr.io/theparanoids/crypki:fb90598 uses a tag, not a digest, to identify the image to sign.
    This can lead you to sign a different image than the intended one. Please use a
    digest (example.com/ubuntu@sha256:abc123...) rather than tag
    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
    images by tag will be removed in a future release.
```