### PR TITLE
update otel semconv to 1.26

### DIFF
--- a/otellib/http.go
+++ b/otellib/http.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 const scopeName = "github.com/theparanoids/crypki/otellib"
@@ -57,7 +57,7 @@ func (h *httpMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	labeler, _ := otelhttp.LabelerFromContext(r.Context())
 	// Add the http.target attribute to the OTel labeler.
 	if r.URL != nil {
-		labeler.Add(semconv.HTTPTargetKey.String(r.URL.RequestURI()))
+		labeler.Add(semconv.HTTPRouteKey.String(r.URL.RequestURI()))
 	}
 	defer func() {
 		if rec := recover(); rec != nil {


### PR DESCRIPTION
To ensure we are always using the semconv v1.26.0 which aligns with the semconv version in `go.opentelemetry.io/otel/sdk@v1.32.0`. It avoids any conflicts when importing back to other projects.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
